### PR TITLE
[NOJIRA] Pam test PR

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -119,7 +119,8 @@ maxConcurrentTotal = maxTotal
 throttleEnabled = throttleDisabled
 
 template = template
-type = OBJECT
+runAtStart = runAtStart
+runAtEnd = runAtEnd
 
 jenkins.model.BuildDiscarderProperty = it / 'properties' / 'jenkins.model.BuildDiscarderProperty'
 jenkins.model.BuildDiscarderProperty.type = CONFIGURE

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -47,8 +47,8 @@ logRotator.daysToKeep.type = METHOD
 configure = configure
 configure.type = OBJECT
 
-org.jenkinsci.plugins.buildnamesetter.BuildNameSetter = it / 'properties' / 'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter'
-org.jenkinsci.plugins.buildnamesetter.BuildNameSetter.type = CONFIGURE
+org.jenkinsci.plugins.buildnamesetter.BuildNameSetter = buildNameSetter
+org.jenkinsci.plugins.buildnamesetter.BuildNameSetter.type = OBJECT
 
 jenkins.plugins.slack.SlackNotifier = it / 'properties' / 'jenkins.plugins.slack.SlackNotifier'
 jenkins.plugins.slack.SlackNotifier.type = CONFIGURE
@@ -121,6 +121,7 @@ throttleEnabled = throttleDisabled
 template = template
 runAtStart = runAtStart
 runAtEnd = runAtEnd
+descriptionTemplate = descriptionTemplate
 
 jenkins.model.BuildDiscarderProperty = it / 'properties' / 'jenkins.model.BuildDiscarderProperty'
 jenkins.model.BuildDiscarderProperty.type = CONFIGURE

--- a/src/test/java/com/adq/jenkins/xmljobtodsl/TestsTranslator.java
+++ b/src/test/java/com/adq/jenkins/xmljobtodsl/TestsTranslator.java
@@ -112,6 +112,11 @@ public class TestsTranslator {
         readFilesAndTest("example-multijob.xml", "example-multijob.groovy");
     }
 
+    @Test
+    public void testBuildNameSetter() throws IOException, ParserConfigurationException, SAXException {
+        readFilesAndTest("buildnamesetter-test.xml", "buildnamesetter-test.groovy");
+    }
+
     private void logAllNotKnownTags(List<PropertyDescriptor> notKnownTags) {
         for (PropertyDescriptor property : notKnownTags) {
             Logger.getAnonymousLogger().log(Level.WARNING, property.getName());

--- a/src/test/resources/buildnamesetter-test.groovy
+++ b/src/test/resources/buildnamesetter-test.groovy
@@ -1,0 +1,9 @@
+job("test") {
+    configure {
+        it / 'properties' / 'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter' {
+            template("#\${BUILD_NUMBER} (\${GIT_BRANCH})")
+            runAtStart(true)
+            runAtEnd(true)
+        }
+    }
+}

--- a/src/test/resources/buildnamesetter-test.groovy
+++ b/src/test/resources/buildnamesetter-test.groovy
@@ -1,9 +1,10 @@
 job("test") {
-    configure {
-        it / 'properties' / 'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter' {
+    wrappers {
+        BuildNameSetter {
             template("#\${BUILD_NUMBER} (\${GIT_BRANCH})")
             runAtStart(true)
             runAtEnd(true)
+            descriptionTemplate()
         }
     }
 }

--- a/src/test/resources/buildnamesetter-test.xml
+++ b/src/test/resources/buildnamesetter-test.xml
@@ -4,6 +4,7 @@
             <template>#${BUILD_NUMBER} (${GIT_BRANCH})</template>
             <runAtStart>true</runAtStart>
             <runAtEnd>true</runAtEnd>
+            <descriptionTemplate/>
         </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
     </buildWrappers>
 </project>

--- a/src/test/resources/buildnamesetter-test.xml
+++ b/src/test/resources/buildnamesetter-test.xml
@@ -1,0 +1,9 @@
+<project>
+    <buildWrappers>
+        <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@2.2.0">
+            <template>#${BUILD_NUMBER} (${GIT_BRANCH})</template>
+            <runAtStart>true</runAtStart>
+            <runAtEnd>true</runAtEnd>
+        </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
+    </buildWrappers>
+</project>


### PR DESCRIPTION
## Ticket
https://jira.tinyspeck.com/browse/BUILD-2434

## Overview
Just trying to fill out contribution docs for this repo, figured I'd start with some simple attributes

The loose "type = object" line was not doing anything, the code specifically looks for attribute.type (eg template.type) and when that cannot be found it assumes it's a method.

Doc for this attribute group: https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#path/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.buildNameSetter

## Testing
XML:
```
<project>
    <buildWrappers>
        <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@2.2.0">
            <template>#${BUILD_NUMBER} (${GIT_BRANCH})</template>
            <runAtStart>true</runAtStart>
            <runAtEnd>true</runAtEnd>
            <descriptionTemplate/>
        </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
    </buildWrappers>
</project>
```

DSL ([source](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.buildNameSetter))
```
job("test") {
	wrappers {
		buildNameSetter {
			template("#\${BUILD_NUMBER} (\${GIT_BRANCH})")
			runAtStart(true)
			runAtEnd(true)
			descriptionTemplate()
		}
	}
}
```