### PR TITLE
[BUILD-2435] Copy artifact permission property

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -177,6 +177,11 @@ command = shell
 hudson.model.ParametersDefinitionProperty = parameters
 hudson.model.ParametersDefinitionProperty.type = OBJECT
 
+hudson.plugins.copyartifact.CopyArtifactPermissionProperty = copyArtifactPermissionProperty
+hudson.plugins.copyartifact.CopyArtifactPermissionProperty.type = OBJECT
+
+projectNameList = projectNames
+
 parameterDefinitions = INNER
 
 hudson.model.StringParameterDefinition = stringParam

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -177,7 +177,7 @@ command = shell
 hudson.model.ParametersDefinitionProperty = parameters
 hudson.model.ParametersDefinitionProperty.type = OBJECT
 
-hudson.plugins.copyartifact.CopyArtifactPermissionProperty = copyArtifactPermissionProperty
+hudson.plugins.copyartifact.CopyArtifactPermissionProperty = copyArtifactPermission
 hudson.plugins.copyartifact.CopyArtifactPermissionProperty.type = OBJECT
 
 projectNameList = projectNames


### PR DESCRIPTION
## Ticket
https://jira.tinyspeck.com/browse/BUILD-2435

## Overview
Test XML used:
```
<flow-definition>
    <actions/>
    <description>A tool for Build team to monitor job creation and deletion. For help: #escal-build For alerts: #team-build-firehose</description>
    <keepDependencies>false</keepDependencies>
    <properties>
        <hudson.plugins.copyartifact.CopyArtifactPermissionProperty plugin="copyartifact@1.47">
            <projectNameList>
                <string>build-team-job-monitor-pipeline</string>
            </projectNameList>
        </hudson.plugins.copyartifact.CopyArtifactPermissionProperty>
... redacted for brevity
```

Output DSL:
```
pipelineJob("test") {
	description("A tool for Build team to monitor job creation and deletion. For help: #escal-build For alerts: #team-build-firehose")
	keepDependencies(false)
	copyArtifactPermission {
		projectNames("build-team-job-monitor-pipeline", "build-team-job-monitor-pipeline2")
	}
```

Source: https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.properties.PropertiesContext.copyArtifactPermission
