### PR TITLE
[Build2780] bug fix translated tags warning

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/InitialArgumentsHandler.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/InitialArgumentsHandler.java
@@ -109,18 +109,20 @@ public class InitialArgumentsHandler {
 			//System.out.println(dsl);
 		}
 		unknownTags = translator.getNotTranslated();
-		HashMap<String,Integer> uniqueUnknownTags = new HashMap<String, Integer>();
-		System.out.println("\n\nWARNING:\nThe following tags couldn't be translated:");
-		for (PropertyDescriptor property : unknownTags) {
-			if (!uniqueUnknownTags.containsKey(property.getName())) uniqueUnknownTags.put(property.getName(), 1);
-			else {
-				uniqueUnknownTags.put(property.getName(), uniqueUnknownTags.get(property.getName()) + 1);
-				continue;
+		if (!unknownTags.isEmpty()) {
+			HashMap<String,Integer> uniqueUnknownTags = new HashMap<String, Integer>();
+			System.out.println("\n\nWARNING:\nThe following tags couldn't be translated:");
+			for (PropertyDescriptor property : unknownTags) {
+				if (!uniqueUnknownTags.containsKey(property.getName())) uniqueUnknownTags.put(property.getName(), 1);
+				else {
+					uniqueUnknownTags.put(property.getName(), uniqueUnknownTags.get(property.getName()) + 1);
+					continue;
+				}
 			}
-		}
 
-		for (Map.Entry<String, Integer> entry : uniqueUnknownTags.entrySet()) {
-			System.out.println(String.format("%s %d", entry.getKey(), entry.getValue()));
+			for (Map.Entry<String, Integer> entry : uniqueUnknownTags.entrySet()) {
+				System.out.println(String.format("%s %d", entry.getKey(), entry.getValue()));
+			}
 		}
 	}
 

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/InitialArgumentsHandler.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/InitialArgumentsHandler.java
@@ -109,20 +109,18 @@ public class InitialArgumentsHandler {
 			//System.out.println(dsl);
 		}
 		unknownTags = translator.getNotTranslated();
-		if (!unknownTags.isEmpty()) {
-			HashMap<String,Integer> uniqueUnknownTags = new HashMap<String, Integer>();
-			System.out.println("\n\nWARNING:\nThe following tags couldn't be translated:");
-			for (PropertyDescriptor property : unknownTags) {
-				if (!uniqueUnknownTags.containsKey(property.getName())) uniqueUnknownTags.put(property.getName(), 1);
-				else {
-					uniqueUnknownTags.put(property.getName(), uniqueUnknownTags.get(property.getName()) + 1);
-					continue;
-				}
+		HashMap<String,Integer> uniqueUnknownTags = new HashMap<String, Integer>();
+		System.out.println("\n\nWARNING:\nThe following tags couldn't be translated:");
+		for (PropertyDescriptor property : unknownTags) {
+			if (!uniqueUnknownTags.containsKey(property.getName())) uniqueUnknownTags.put(property.getName(), 1);
+			else {
+				uniqueUnknownTags.put(property.getName(), uniqueUnknownTags.get(property.getName()) + 1);
+				continue;
 			}
+		}
 
-			for (Map.Entry<String, Integer> entry : uniqueUnknownTags.entrySet()) {
-				System.out.println(String.format("%s %d", entry.getKey(), entry.getValue()));
-			}
+		for (Map.Entry<String, Integer> entry : uniqueUnknownTags.entrySet()) {
+			System.out.println(String.format("%s %d", entry.getKey(), entry.getValue()));
 		}
 	}
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -50,8 +50,8 @@ configure.type = OBJECT
 org.jenkinsci.plugins.buildnamesetter.BuildNameSetter = it / 'properties' / 'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter'
 org.jenkinsci.plugins.buildnamesetter.BuildNameSetter.type = CONFIGURE
 
-jenkins.plugins.slack.SlackNotifier = it / 'properties' / 'jenkins.plugins.slack.SlackNotifier'
-jenkins.plugins.slack.SlackNotifier.type = CONFIGURE
+jenkins.plugins.slack.SlackNotifier = slackNotifier
+jenkins.plugins.slack.SlackNotifier.type = OBJECT
 
 baseUrl = baseUrl
 baseUrl.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
@@ -96,46 +96,32 @@ customMessageUnstable = customMessageUnstable
 customMessageFailure = customMessageFailure
 
 notifySuccess = notifySuccess
-notifySuccess.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyAborted = notifyAborted
-notifyAborted.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyNotBuilt = notifyNotBuilt
-notifyNotBuilt.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyRegression = notifyRegression
-notifyRegression.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyUnstable = notifyUnstable
-notifyUnstable.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyFailure = notifyFailure
-notifyFailure.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyBackToNormal = notifyBackToNormal
-notifyBackToNormal.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyRepeatedFailure = notifyRepeatedFailure
-notifyRepeatedFailure.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 includeTestSummary = includeTestSummary
-includeTestSummary.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 includeFailedTests = includeFailedTests
-includeFailedTests.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 includeCustomMessage = includeCustomMessage
-#includeCustomMessage.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 customMessage = customMessage
-#customMessage.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 commitInfoChoice = commitInfoChoice
-commitInfoChoice.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 startNotification = startNotification
-startNotification.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 hudson.plugins.throttleconcurrents.ThrottleJobProperty = throttleConcurrentBuilds
 maxConcurrentPerNode = maxPerNode

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -71,6 +71,30 @@ jenkins.plugins.slack.SlackNotifier.authToken.type = com.adq.jenkins.xmljobtodsl
 authTokenCredentialId = teamDomain
 authTokenCredentialId.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
+tokenCredentialId = tokenCredentialId
+
+iconEmoji = iconEmoji
+
+uploadFiles = uploadFiles
+
+sendAsText = sendAsText
+
+artifactIncludes = artifactIncludes
+
+username = username
+
+notifyEveryFailure = notifyEveryFailure
+
+customMessageAborted = customMessageAborted
+
+customMessageSuccess = customMessageSuccess
+
+customMessageNotBuilt = customMessageNotBuilt
+
+customMessageUnstable = customMessageUnstable
+
+customMessageFailure = customMessageFailure
+
 notifySuccess = notifySuccess
 notifySuccess.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
@@ -102,10 +126,10 @@ includeFailedTests = includeFailedTests
 includeFailedTests.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 includeCustomMessage = includeCustomMessage
-includeCustomMessage.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
+#includeCustomMessage.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 customMessage = customMessage
-customMessage.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
+#customMessage.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 commitInfoChoice = commitInfoChoice
 commitInfoChoice.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -50,8 +50,8 @@ configure.type = OBJECT
 org.jenkinsci.plugins.buildnamesetter.BuildNameSetter = it / 'properties' / 'org.jenkinsci.plugins.buildnamesetter.BuildNameSetter'
 org.jenkinsci.plugins.buildnamesetter.BuildNameSetter.type = CONFIGURE
 
-jenkins.plugins.slack.SlackNotifier = slackNotifier
-jenkins.plugins.slack.SlackNotifier.type = OBJECT
+jenkins.plugins.slack.SlackNotifier = it / 'properties' / 'jenkins.plugins.slack.SlackNotifier'
+jenkins.plugins.slack.SlackNotifier.type = CONFIGURE
 
 baseUrl = baseUrl
 baseUrl.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
@@ -71,57 +71,47 @@ jenkins.plugins.slack.SlackNotifier.authToken.type = com.adq.jenkins.xmljobtodsl
 authTokenCredentialId = teamDomain
 authTokenCredentialId.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
-tokenCredentialId = tokenCredentialId
-
-iconEmoji = iconEmoji
-
-uploadFiles = uploadFiles
-
-sendAsText = sendAsText
-
-artifactIncludes = artifactIncludes
-
-username = username
-
-notifyEveryFailure = notifyEveryFailure
-
-customMessageAborted = customMessageAborted
-
-customMessageSuccess = customMessageSuccess
-
-customMessageNotBuilt = customMessageNotBuilt
-
-customMessageUnstable = customMessageUnstable
-
-customMessageFailure = customMessageFailure
-
 notifySuccess = notifySuccess
+notifySuccess.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyAborted = notifyAborted
+notifyAborted.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyNotBuilt = notifyNotBuilt
+notifyNotBuilt.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyRegression = notifyRegression
+notifyRegression.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyUnstable = notifyUnstable
+notifyUnstable.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyFailure = notifyFailure
+notifyFailure.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyBackToNormal = notifyBackToNormal
+notifyBackToNormal.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 notifyRepeatedFailure = notifyRepeatedFailure
+notifyRepeatedFailure.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 includeTestSummary = includeTestSummary
+includeTestSummary.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 includeFailedTests = includeFailedTests
+includeFailedTests.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 includeCustomMessage = includeCustomMessage
+includeCustomMessage.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 customMessage = customMessage
+customMessage.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 commitInfoChoice = commitInfoChoice
+commitInfoChoice.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 startNotification = startNotification
+startNotification.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
 hudson.plugins.throttleconcurrents.ThrottleJobProperty = throttleConcurrentBuilds
 maxConcurrentPerNode = maxPerNode


### PR DESCRIPTION
## Ticket

[JIRA-2780](hhttps://jira.tinyspeck.com/browse/BUILD-2780)

## Overview

Warning message was printing even when all tags were translated. Removes warning message if all tags for a job are translated.
```
WARNING:
The following tags couldn't be translated:
```

## Testing

Test XML Used:

```
<flow-definition>
    <actions/>
    <description>A tool for Build team to monitor job creation and deletion. For help: #escal-build For alerts: #team-build-firehose</description>
    <keepDependencies>false</keepDependencies>
    <properties>
        <hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.StringParameterDefinition>
                    <name>ALERT_CHANNEL</name>
                    <defaultValue>C01MD3NF12Q</defaultValue>
                    <description>If you need to test, you could change it to your username to receive the notifications, eg @pgluss</description>
                </hudson.model.StringParameterDefinition>
            </parameterDefinitions>
        </hudson.model.ParametersDefinitionProperty>
        <com.sonyericsson.rebuild.RebuildSettings>
            <autoRebuild>false</autoRebuild>
            <rebuildDisabled>false</rebuildDisabled>
        </com.sonyericsson.rebuild.RebuildSettings>
    </properties>
    <triggers>
        <hudson.triggers.TimerTrigger>
            <spec>H 9 * * 1-5</spec>
        </hudson.triggers.TimerTrigger>
    </triggers>
    <disabled>false</disabled>
    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition">
        <script>import jenkins.model.Jenkins import com.cloudbees.hudson.plugins.folder.* def getCurrentJobs() { def results = [] Jenkins.instance.getAllItems(Job).each { results.push(it.name) } return results } def compareJobLists(oldJobList, newJobList) { def commons = newJobList.intersect(oldJobList) newJobList.removeAll(commons) oldJobList.removeAll(commons) return [oldJobList, newJobList] } node { copyArtifacts(projectName: '${JOB_NAME}', filter: 'oldJobList.txt' ) def prevFile = readFile 'oldJobList.txt' def prevJobsListRaw = prevFile.split(', ') def prevJobsList = [] prevJobsListRaw.each { prevJobsList.push(it) } currentJobsList = getCurrentJobs() sh 'rm oldJobList.txt || true' writeFile file: 'oldJobList.txt', text: currentJobsList.join(', ') archiveArtifacts artifacts: 'oldJobList.txt' def changes = compareJobLists(prevJobsList, currentJobsList) if (changes[0].size() > 0 || changes[1].size() > 0) { def message = "Detected a change in jobs on ${env.JENKINS_URL}.\n" if (changes[0].size() > 0) { message += ' The following were deleted:\n' changes[0].each { message += " * ${it}\n" } } if (changes[1].size() > 0) { message += ' The following were created:\n' changes[1].each { message += " * ${it}\n" } } // Send this message to Slack println message sh """ echo "$message" | slack --cat --channel="${env.ALERT_CHANNEL}" --user="Build Team Reporting" """ } else { println 'No changes detected, skipping update' } } </script>
        <sandbox>true</sandbox>
    </definition>
</flow-definition>

```

DSL Output:
```
pipelineJob("test") {
	description("A tool for Build team to monitor job creation and deletion. For help: #escal-build For alerts: #team-build-firehose")
	keepDependencies(false)
	parameters {
		stringParam("ALERT_CHANNEL", "C01MD3NF12Q", "If you need to test, you could change it to your username to receive the notifications, eg @pgluss")
	}
	disabled(false)
	definition {
		cpsScm {
"import jenkins.model.Jenkins import com.cloudbees.hudson.plugins.folder.* def getCurrentJobs() { def results = [] Jenkins.instance.getAllItems(Job).each { results.push(it.name) } return results } def compareJobLists(oldJobList, newJobList) { def commons = newJobList.intersect(oldJobList) newJobList.removeAll(commons) oldJobList.removeAll(commons) return [oldJobList, newJobList] } node { copyArtifacts(projectName: '\${JOB_NAME}', filter: 'oldJobList.txt' ) def prevFile = readFile 'oldJobList.txt' def prevJobsListRaw = prevFile.split(', ') def prevJobsList = [] prevJobsListRaw.each { prevJobsList.push(it) } currentJobsList = getCurrentJobs() sh 'rm oldJobList.txt || true' writeFile file: 'oldJobList.txt', text: currentJobsList.join(', ') archiveArtifacts artifacts: 'oldJobList.txt' def changes = compareJobLists(prevJobsList, currentJobsList) if (changes[0].size() > 0 || changes[1].size() > 0) { def message = \"Detected a change in jobs on \${env.JENKINS_URL}.\\n\" if (changes[0].size() > 0) { message += ' The following were deleted:\\n' changes[0].each { message += \" * \${it}\\n\" } } if (changes[1].size() > 0) { message += ' The following were created:\\n' changes[1].each { message += \" * \${it}\\n\" } } // Send this message to Slack println message sh \"\"\" echo \"\$message\" | slack --cat --channel=\"\${env.ALERT_CHANNEL}\" --user=\"Build Team Reporting\" \"\"\" } else { println 'No changes detected, skipping update' } }"		}
	}
	configure {
		it / 'properties' / 'com.sonyericsson.rebuild.RebuildSettings' {
			'autoRebuild'('false')
			'rebuildDisabled'('false')
		}
	}
}


No untranslated tag! Fit for moving
```
