### PR TITLE
[BUILD-2853] adds missing attributes under postBuildScript-> config

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -432,12 +432,26 @@ RunIfJobSuccessful.type = PARAMETER
 script = script
 script.type = PARAMETER
 
-org.jenkinsci.plugins.postbuildscript.PostBuildScript = postBuildScripts
+org.jenkinsci.plugins.postbuildscript.PostBuildScript = postBuildScript
 org.jenkinsci.plugins.postbuildscript.PostBuildScript.type = OBJECT
 
 config = INNER
 
-buildSteps = steps
+scriptFiles = genericScriptFiles
+scriptFiles.type = OBJECT
+
+groovyScripts = groovyScripts
+groovyScripts.type = OBJECT
+
+results = results
+
+role = role
+
+executeOn = executeOn
+
+stopOnFailure = stopOnFailure
+
+buildSteps = buildSteps
 buildSteps.type = OBJECT
 
 markBuildUnstable = markBuildUnstable
@@ -446,7 +460,9 @@ scriptOnlyIfSuccess = onlyIfBuildSucceeds
 
 scriptOnlyIfFailure = onlyIfBuildFails
 
-org.jenkinsci.plugins.postbuildscript.model.PostBuildStep = INNER
+org.jenkinsci.plugins.postbuildscript.model.PostBuildStep = postBuildStep
+org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.type = OBJECT
+
 
 hudson.tasks.Mailer = mailer
 


### PR DESCRIPTION
## Ticket

[JIRA-2853](https://jira.tinyspeck.com/browse/BUILD-2853)

## Overview
Adding the missing attributes: 
- scriptFiles
- groovyScripts
- results
- role
- executeOn
- stopOnFailure

changed name for buildSteps from "steps" to "buildSteps" as that's how it appears in the DSL in this context. PostBuildStep as an INNER was not rendering correctly to match the DSL so it was changed to an OBJECT

## Testing

Test XML Used:
```
<project>
    <publishers>
        <org.jenkinsci.plugins.postbuildscript.PostBuildScript plugin="postbuildscript@3.1.0-375.v3db_cd92485e1">
            <config>
                <scriptFiles/>
                <groovyScripts/>
                <buildSteps>
                    <org.jenkinsci.plugins.postbuildscript.model.PostBuildStep>
                        <results>
                            <string>SUCCESS</string>
                            <string>NOT_BUILT</string>
                            <string>ABORTED</string>
                            <string>FAILURE</string>
                            <string>UNSTABLE</string>
                        </results>
                        <role>SLAVE</role>
                        <executeOn>BOTH</executeOn>
                        <buildSteps>
                            <hudson.tasks.Shell>
                                <command># Clean up folder for output rm -rf tests/rspec-api-tests/tmp || true mkdir tests/rspec-api-tests/tmp # Get the name of the container from this run CONTAINER_NAME="$(cat container_name.txt)" # Copy the rspec output docker cp "${CONTAINER_NAME}":/home/slack/tests/rspec-api-tests/output/rspec.xml "${WORKSPACE}"/tests/rspec-api-tests/tmp/rspec.xml # Remove the container docker rm "${CONTAINER_NAME}"</command>
                            </hudson.tasks.Shell>
                        </buildSteps>
                        <stopOnFailure>false</stopOnFailure>
                    </org.jenkinsci.plugins.postbuildscript.model.PostBuildStep>
                </buildSteps>
                <markBuildUnstable>false</markBuildUnstable>
            </config>
        </org.jenkinsci.plugins.postbuildscript.PostBuildScript>
    </publishers>
</project>
```

DSL Output:
```
job("test") {
	publishers {
		postBuildScript {
			buildSteps {
				postBuildStep {
					results("SUCCESS", "NOT_BUILT", "ABORTED", "FAILURE", "UNSTABLE")
					role("SLAVE")
					executeOn("BOTH")
					buildSteps {
						shell("# Clean up folder for output rm -rf tests/rspec-api-tests/tmp || true mkdir tests/rspec-api-tests/tmp # Get the name of the container from this run CONTAINER_NAME=\"\$(cat container_name.txt)\" # Copy the rspec output docker cp \"\${CONTAINER_NAME}\":/home/slack/tests/rspec-api-tests/output/rspec.xml \"\${WORKSPACE}\"/tests/rspec-api-tests/tmp/rspec.xml # Remove the container docker rm \"\${CONTAINER_NAME}\"")
					}
					stopOnFailure(false)
				}
			}
			markBuildUnstable(false)
		}
	}
}
```
