### PR TITLE
BUILD-2854 jUnitResultArchiver attributes

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -482,15 +482,14 @@ excludePattern = excludePattern
 failBuildWhenCleanupFails = failBuildWhenCleanupFails
 includePattern = includePattern
 
-hudson.tasks.junit.JUnitResultArchiver = archiveJunit
-hudson.tasks.junit.JUnitResultArchiver.type = CLOSURE
+hudson.tasks.junit.JUnitResultArchiver = jUnitResultArchiver
+hudson.tasks.junit.JUnitResultArchiver.type = OBJECT
 
-hudson.tasks.junit.JUnitResultArchiver.testResults = testResults
-hudson.tasks.junit.JUnitResultArchiver.testResults.type = PARAMETER
+testResults = testResults
 
 healthScaleFactor = healthScaleFactor
 
-keepLongStdio = retainLongStdout
+keepLongStdio = keepLongStdio
 
 allowEmptyResults = allowEmptyResults
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -494,6 +494,14 @@ keepLongStdio = retainLongStdout
 
 allowEmptyResults = allowEmptyResults
 
+checksName = checksName
+
+skipPublishingChecks = skipPublishingChecks
+
+skipMarkingBuildUnstable = skipMarkingBuildUnstable
+
+skipOldReports = skipOldReports
+
 com.cloudbees.jenkins.GitHubCommitNotifier = githubCommitNotifier
 
 hudson.plugins.build__timeout.BuildTimeoutWrapper = timeout


### PR DESCRIPTION
## Ticket

[JIRA-2854](https://jira.tinyspeck.com/browse/BUILD-2854)

## Overview
Changes variable name for attribute to jUnitResultArchiver and type to object. Adds the following missing attributes under jUnitResultArchiver:

- checksName

- skipPublishingChecks

- skipMarkingBuildUnstable

- skipOldReports

## Testing

Test XML Used:
```
<project>
    <actions/>
    <description>Test</description>
    <keepDependencies>false</keepDependencies>
    <publishers>
        <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.63">
            <testResults>tests/rspec-api-tests/tmp/rspec.xml</testResults>
            <keepLongStdio>false</keepLongStdio>
            <healthScaleFactor>1.0</healthScaleFactor>
            <allowEmptyResults>true</allowEmptyResults>
            <skipPublishingChecks>false</skipPublishingChecks>
            <checksName/>
            <skipMarkingBuildUnstable>false</skipMarkingBuildUnstable>
            <skipOldReports>False</skipOldReports>
        </hudson.tasks.junit.JUnitResultArchiver>
    </publishers>
</project>
```

DSL Output:
```
job("test") {
	description("Test")
	keepDependencies(false)
	publishers {
		jUnitResultArchiver {
			testResults("tests/rspec-api-tests/tmp/rspec.xml")
			keepLongStdio(false)
			healthScaleFactor(1.0)
			allowEmptyResults(true)
			skipPublishingChecks(false)
			checksName()
			skipMarkingBuildUnstable(false)
			skipOldReports(False)
		}
	}
}


No untranslated tag! Fit for moving
```
