### PR TITLE
BUILD-2866-submoduleOption property

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -268,7 +268,6 @@ trackingSubmodules = trackingSubmodules
 parentCredentials = parentCredentials
 threads = threads
 
-
 userRemoteConfigs = INNER
 
 hudson.plugins.git.UserRemoteConfig = remote

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -260,6 +260,15 @@ git.type = OBJECT
 doGenerateSubmoduleConfigurations=doGenerateSubmoduleConfigurations
 doGenerateSubmoduleConfigurations.type=OBJECT
 
+hudson.plugins.git.extensions.impl.SubmoduleOption = submoduleOption
+hudson.plugins.git.extensions.impl.SubmoduleOption.type = OBJECT
+disableSubmodules = disableSubmodules
+recursiveSubmodules = recursiveSubmodules
+trackingSubmodules = trackingSubmodules
+parentCredentials = parentCredentials
+threads = threads
+
+
 userRemoteConfigs = INNER
 
 hudson.plugins.git.UserRemoteConfig = remote


### PR DESCRIPTION
## Ticket

[JIRA-2866](https://jira.tinyspeck.com/browse/BUILD-2866)

## Overview
Adding the missing attributes for hudson.plugins.git.extensions.impl.SubmoduleOption

## Testing

Test XML Used:
```
<project>
    <scm class="hudson.plugins.git.GitSCM" plugin="git@4.11.1">
        <configVersion>2</configVersion>
        <userRemoteConfigs>
            <hudson.plugins.git.UserRemoteConfig>
                <url>git@slack-github.com:slack/apache2.git</url>
                <credentialsId>Jenkins-GHE</credentialsId>
            </hudson.plugins.git.UserRemoteConfig>
        </userRemoteConfigs>
        <branches>
            <hudson.plugins.git.BranchSpec>
                <name>*/main</name>
            </hudson.plugins.git.BranchSpec>
        </branches>
        <extensions>
            <hudson.plugins.git.extensions.impl.CloneOption>
                <shallow>false</shallow>
                <noTags>false</noTags>
                <reference/>
                <honorRefspec>false</honorRefspec>
            </hudson.plugins.git.extensions.impl.CloneOption>
            <hudson.plugins.git.extensions.impl.SubmoduleOption>
                <disableSubmodules>false</disableSubmodules>
                <recursiveSubmodules>true</recursiveSubmodules>
                <trackingSubmodules>false</trackingSubmodules>
                <reference/>
                <parentCredentials>false</parentCredentials>
                <shallow>false</shallow>
            </hudson.plugins.git.extensions.impl.SubmoduleOption>
        </extensions>
    </scm>
</project>
```

DSL Output:
```
job("test") {
	scm {
		git {
			remote {
				github("slack/apache2", "ssh")
				credentials("Jenkins-GHE")
			}
			branch("*/main")
			extensions {
				cloneOption {
					shallow(false)
					noTags(false)
					reference()
					honorRefspec(false)
				}
				submoduleOption {
					disableSubmodules(false)
					recursiveSubmodules(true)
					trackingSubmodules(false)
					reference()
					parentCredentials(false)
					shallow(false)
				}
			}
		}
	}
}
```
