### PR TITLE
[BUILD-2851]-throttle job property

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -49,10 +49,6 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("caseSensitive");
 		propertiesToBeSkipped.add("EnvInjectPasswordWrapper");
 		propertiesToBeSkipped.add("followSymlinks");
-        propertiesToBeSkipped.add("paramsToUseForLimit");
-		propertiesToBeSkipped.add("limitOneJobWithMatchingParams");
-		propertiesToBeSkipped.add("categories");
-		propertiesToBeSkipped.add("throttleOption");
 		propertiesToBeSkipped.add("completeBuild");
 		propertiesToBeSkipped.add("externalDelete");
 		propertiesToBeSkipped.add("skipWhenFailed");

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -130,7 +130,8 @@ commitInfoChoice = commitInfoChoice
 startNotification = startNotification
 
 hudson.plugins.throttleconcurrents.ThrottleJobProperty = throttleJobProperty
-maxConcurrentPerNode =maxConcurrentPerNod
+hudson.plugins.throttleconcurrents.ThrottleJobProperty.type = OBJECT
+maxConcurrentPerNode =maxConcurrentPerNode
 maxConcurrentTotal = maxConcurrentTotal
 categories = categories
 throttleEnabled = throttleEnabled

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -129,10 +129,17 @@ commitInfoChoice = commitInfoChoice
 
 startNotification = startNotification
 
-hudson.plugins.throttleconcurrents.ThrottleJobProperty = throttleConcurrentBuilds
-maxConcurrentPerNode = maxPerNode
-maxConcurrentTotal = maxTotal
-throttleEnabled = throttleDisabled
+hudson.plugins.throttleconcurrents.ThrottleJobProperty = throttleJobProperty
+maxConcurrentPerNode =maxConcurrentPerNod
+maxConcurrentTotal = maxConcurrentTotal
+categories = categories
+throttleEnabled = throttleEnabled
+throttleOption = throttleOption
+limitOneJobWithMatchingParams = limitOneJobWithMatchingParams
+paramsToUseForLimit = paramsToUseForLimit
+matrixOptions = OBJECT
+throttleMatrixBuilds = throttleMatrixBuilds
+throttleMatrixConfigurations = throttleMatrixConfigurations
 
 template = template
 runAtStart = runAtStart


### PR DESCRIPTION
## Ticket

[JIRA-2851](https://jira.tinyspeck.com/browse/BUILD-2851)

## Overview

Add missing attributes for throttleJobProperty. A few were listed under propertiesToBeSkipped; however, are supported by the Jenkins Job DSL Plugin so they were removed as properties to be ignored. 

## Testing

Test XML Used:
```
<project>
    <actions/>
    <description>Test</description>
    <keepDependencies>false</keepDependencies>
    <properties>
        <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@2.8">
            <maxConcurrentPerNode>0</maxConcurrentPerNode>
            <maxConcurrentTotal>0</maxConcurrentTotal>
            <categories class="java.util.concurrent.CopyOnWriteArrayList"/>
            <throttleEnabled>false</throttleEnabled>
            <throttleOption>project</throttleOption>
            <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
            <paramsToUseForLimit/>
            <configVersion>1</configVersion>
        </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
    </properties>
</project>
```

DSL Output:
```
job("Test") {
	description("Test")
	keepDependencies(false)
	properties {
		throttleJobProperty {
			maxConcurrentPerNode(0)
			maxConcurrentTotal(0)
			categories()
			throttleEnabled(false)
			throttleOption("project")
			limitOneJobWithMatchingParams(false)
			paramsToUseForLimit()
		}
	}
}


No untranslated tag! Fit for moving

```
