### PR TITLE
[BUILD-2901] sshUserPrivateKeyProperty

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -554,6 +554,13 @@ cleanupParameter = cleanupParameter
 
 com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper = sshAgent
 
+org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding = sshUserPrivateKey
+org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding.type = OBJECT
+
+keyFileVariable = keyFileVariable
+
+passphraseVariable = passphraseVariable
+
 credentialIds = INNER
 
 credentialIds.string = credentialIds
@@ -771,7 +778,6 @@ org.bstick12.jenkinsci.plugins.leastload.LeastLoadDisabledProperty =LeastLoadDis
 org.bstick12.jenkinsci.plugins.leastload.LeastLoadDisabledProperty.type = OBJECT
 
 leastLoadDisabled = leastLoadDisabled
-
 
 cron = cron
 


### PR DESCRIPTION
## Ticket

[JIRA-2901](https://jira.tinyspeck.com/browse/BUILD-2901)

## Overview

Referencing [this](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#path/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.credentialsBinding-sshUserPrivateKey) to add properties for sshUserPrivateKey

## Testing

Test XML Used:
```
<project>
    <actions/>
    <description>Test </description>
    <keepDependencies>false</keepDependencies>
    <buildWrappers>
    <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@523.vd859a_4b_122e6">
        <bindings>
            <org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
                <credentialsId>JENKINS_SLACK_GITHUB_BOT_TOKEN</credentialsId>
                <usernameVariable>SECRET_GHE_USERNAME</usernameVariable>
                <passwordVariable>SECRET_GHE_PASSWORD</passwordVariable>
            </org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
            <org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
                <credentialsId>SNOW_CHECKPOINT_TOKEN</credentialsId>
                <variable>CHECKPOINT_TOKEN</variable>
            </org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
            <org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
                <credentialsId>SNOW_TSAUTH_TOKEN</credentialsId>
                <variable>SNOW_TSAUTH_TOKEN</variable>
            </org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
            <org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
                <credentialsId>JENKINS_MIGRATED_SLACK_TOKEN</credentialsId>
                <variable>SNOW_ALERT_WEBHOOK</variable>
            </org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
            <org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
                <credentialsId>Jenkins-PRODSEC_SNOW_PRIVATE_KEY</credentialsId>
                <keyFileVariable>GHC_PRIVATE_KEY</keyFileVariable>
                <usernameVariable>svc-ghe-snow</usernameVariable>
            </org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
            <org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
                <credentialsId>Jenkins-GHE</credentialsId>
                <keyFileVariable>GHE_PRIVATE_KEY</keyFileVariable>
                <usernameVariable>jenkins</usernameVariable>
            </org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
        </bindings>
    </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.18"/>
    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.21">
        <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
            <timeoutMinutes>180</timeoutMinutes>
        </strategy>
        <operationList>
            <hudson.plugins.build__timeout.operations.AbortOperation/>
        </operationList>
    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
    </buildWrappers>
</project>
```

DSL Output:
```
job("Test") {
	description("Test")
	keepDependencies(false)
	wrappers {
		credentialsBinding {
			usernamePassword {
				credentialsId("JENKINS_SLACK_GITHUB_BOT_TOKEN")
				usernameVariable("SECRET_GHE_USERNAME")
				passwordVariable("SECRET_GHE_PASSWORD")
			}
			string("CHECKPOINT_TOKEN")
			string("SNOW_TSAUTH_TOKEN")
			string("SNOW_ALERT_WEBHOOK")
			sshUserPrivateKey {
				credentialsId("Jenkins-PRODSEC_SNOW_PRIVATE_KEY")
				keyFileVariable("GHC_PRIVATE_KEY")
				usernameVariable("svc-ghe-snow")
			}
			sshUserPrivateKey {
				credentialsId("Jenkins-GHE")
				keyFileVariable("GHE_PRIVATE_KEY")
				usernameVariable("jenkins")
			}
		}
		timestamps()
		timeout {
			absolute(180)
		}
	}
}


No untranslated tag! Fit for moving
```
