### PR TITLE
BUILD-2909-hudson.model.ParametersDefinitionProperty

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -38,7 +38,6 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		this.tabs = tabs;
 		this.propertyDescriptor = descriptor;
 		propertiesToBeSkipped.add("actions");
-		propertiesToBeSkipped.add("trim");
 		propertiesToBeSkipped.add("configVersion");
 		propertiesToBeSkipped.add("submoduleCfg");
 		propertiesToBeSkipped.add("doGenerateSubmoduleConfigurations");

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -56,7 +56,6 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("hudson.plugins.git.extensions.impl.PathRestriction");
 		propertiesToBeSkipped.add("unstableReturn");
 		propertiesToBeSkipped.add("ignoreMissing");
-		propertiesToBeSkipped.add("pre");
 
 		try {
 			initProperties();

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -56,6 +56,7 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("hudson.plugins.git.extensions.impl.PathRestriction");
 		propertiesToBeSkipped.add("unstableReturn");
 		propertiesToBeSkipped.add("ignoreMissing");
+		propertiesToBeSkipped.add("pre");
 
 		try {
 			initProperties();

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -209,22 +209,22 @@ hudson.plugins.copyartifact.CopyArtifactPermissionProperty.type = OBJECT
 
 projectNameList = projectNames
 
-parameterDefinitions = INNER
+parameterDefinitions = parameterDefinitions
+parameterDefinitions.type = OBJECT
 
 hudson.model.StringParameterDefinition = stringParam
-hudson.model.StringParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
+hudson.model.StringParameterDefinition.type = OBJECT
 
 hudson.model.TextParameterDefinition = textParam
 hudson.model.TextParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
-name = PARAM_NAME
-name.type = PARAMETER
+name = name
 
-defaultValue = PARAM_DEFAULT_VALUE
-defaultValue.type = PARAMETER
+defaultValue = defaultValue
 
-description = PARAM_DESCRIPTION
-description.type = PARAMETER
+description = description
+
+trim = trim
 
 com.cloudbees.plugins.credentials.CredentialsParameterDefinition = credentialsParam
 com.cloudbees.plugins.credentials.CredentialsParameterDefinition.type = CLOSURE
@@ -241,10 +241,9 @@ credentialType = type
 credentialType.type = PARAMETER
 
 hudson.model.ChoiceParameterDefinition = choiceParam
-hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
+hudson.model.ChoiceParameterDefinition.type = OBJECT
 
-choices = INNER
-choices.type = INNER
+choices = choices
 
 a = a
 a.type = ARRAY
@@ -253,7 +252,7 @@ string = string
 string.type = PARAMETER
 
 hudson.model.BooleanParameterDefinition = booleanParam
-hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
+hudson.model.BooleanParameterDefinition.type = OBJECT
 
 scm = scm
 scm.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLHiddenTagStrategy

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -251,6 +251,9 @@ a.type = ARRAY
 string = string
 string.type = PARAMETER
 
+pre = pre
+pre.type = PARAMETER
+
 hudson.model.BooleanParameterDefinition = booleanParam
 hudson.model.BooleanParameterDefinition.type = OBJECT
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -224,6 +224,9 @@ description = description
 
 trim = trim
 
+pre = pre
+pre.type = PARAMETER
+
 com.cloudbees.plugins.credentials.CredentialsParameterDefinition = credentialsParam
 com.cloudbees.plugins.credentials.CredentialsParameterDefinition.type = CLOSURE
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -164,6 +164,8 @@ strategy.artifactDaysToKeep.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.cu
 strategy.artifactNumToKeep = artifactNumToKeep
 strategy.artifactNumToKeep.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
+hudson.plugins.git.extensions.impl.GitLFSPull = gitLFSPull
+
 com.coravy.hudson.plugins.github.GithubProjectProperty = it / 'properties' / 'com.coravy.hudson.plugins.github.GithubProjectProperty'
 com.coravy.hudson.plugins.github.GithubProjectProperty.type = CONFIGURE
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -249,9 +249,6 @@ a.type = ARRAY
 string = string
 string.type = PARAMETER
 
-pre = pre
-pre.type = PARAMETER
-
 hudson.model.BooleanParameterDefinition = booleanParam
 hudson.model.BooleanParameterDefinition.type = OBJECT
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -164,8 +164,6 @@ strategy.artifactDaysToKeep.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.cu
 strategy.artifactNumToKeep = artifactNumToKeep
 strategy.artifactNumToKeep.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLNonSupportedMethodDSL
 
-hudson.plugins.git.extensions.impl.GitLFSPull = gitLFSPull
-
 com.coravy.hudson.plugins.github.GithubProjectProperty = it / 'properties' / 'com.coravy.hudson.plugins.github.GithubProjectProperty'
 com.coravy.hudson.plugins.github.GithubProjectProperty.type = CONFIGURE
 


### PR DESCRIPTION
## Ticket

[JIRA-2909](https://jira.tinyspeck.com/browse/BUILD-2909)

## Overview

Noticed that nothing under the  hudson.model.ParametersDefinitionProperty section of the xml was being translated.

<img width="411" alt="Screen Shot 2022-10-20 at 1 40 41 PM" src="https://user-images.githubusercontent.com/112515811/197037046-5b67a6c8-878f-41a0-bb6e-0a08eaf294b9.png">

 The `<pre>` tag was added within a "description" block in the UI for formatting so it's now added a parameter in order to convert correctly.

## Testing

Test XML Used:
```
<project>
    <actions/>
    <description>Test</description>
    <keepDependencies>false</keepDependencies>
    <properties>
        <hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.ChoiceParameterDefinition>
                    <name>DEPLOY_GROUP</name>
                    <description><pre>Group of hosts to upgrade: Testing</pre></description>
                    <choices class="java.util.Arrays$ArrayList">
                        <a class="string-array">
                            <string>role:notraffic</string>
                            <string>dogfood:all</string>
                            <string>role:pepper</string>
                            <string>role:heavy_pepper</string>
                            <string>smart</string>
                        </a>
                    </choices>
                </hudson.model.ChoiceParameterDefinition>
                <hudson.model.BooleanParameterDefinition>
                    <name>DRY_RUN</name>
                    <description>Make this a dry run that shows the list of hosts that would be upgraded</description>
                    <defaultValue>true</defaultValue>
                </hudson.model.BooleanParameterDefinition>
                <hudson.model.StringParameterDefinition>
                    <name>DEPLOY_HOSTS</name>
                    <description>Deploy to specified hosts</description>
                    <trim>false</trim>
                </hudson.model.StringParameterDefinition>
            </parameterDefinitions>
        </hudson.model.ParametersDefinitionProperty>
    </properties>
</project>
```

DSL Output:
```
job("Test") {
	description("Test")
	keepDependencies(false)
	properties {
		parameters {
			parameterDefinitions {
				choiceParam {
					name("DEPLOY_GROUP")
					description("Group of hosts to upgrade: Testing")
					choices(["role:notraffic", "dogfood:all", "role:pepper", "role:heavy_pepper", "smart"])
				}
				booleanParam {
					name("DRY_RUN")
					description("Make this a dry run that shows the list of hosts that would be upgraded")
					defaultValue(true)
				}
				stringParam {
					name("DEPLOY_HOSTS")
					description("Deploy to specified hosts")
					trim(false)
				}
			}
		}
	}
}


No untranslated tag! Fit for moving
```
