### PR TITLE
BUILD-2961 sandbox property and edits to envInjectBuildWrapper

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -43,7 +43,6 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("submoduleCfg");
 		propertiesToBeSkipped.add("doGenerateSubmoduleConfigurations");
 		propertiesToBeSkipped.add("canRoam");
-		propertiesToBeSkipped.add("sandbox");
 		propertiesToBeSkipped.add("operationList");
 		propertiesToBeSkipped.add("spec");
 		propertiesToBeSkipped.add("caseSensitive");

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -739,10 +739,10 @@ scriptPath = scriptPath
 EnvInjectJobProperty = environmentVariables
 EnvInjectJobProperty.type = OBJECT
 
-EnvInjectBuildWrapper = environmentVariables
+EnvInjectBuildWrapper = EnvInjectBuildWrapper
 EnvInjectBuildWrapper.type = OBJECT
 
-EnvInjectBuildWrapper.info.loadFilesFromMaster = INNER
+#EnvInjectBuildWrapper.info.loadFilesFromMaster = INNER
 
 EnvInjectJobProperty.keepBuildVariables = keepBuildVariables
 
@@ -755,16 +755,20 @@ contributors.type = OBJECT
 
 loadFilesFromMaster = loadFilesFromMaster
 
-secureGroovyScript = INNER
+secureGroovyScript = secureGroovyScript
+secureGroovyScript.type = OBJECT
 
-secureGroovyScript.script = groovy
+secureGroovyScript.script = script
 
-EnvInjectBuildWrapper.info = INNER
+sandbox = sandbox
 
-info = INNER
+EnvInjectBuildWrapper.info = info
+EnvInjectBuildWrapper.info.type = OBJECT
 
-propertiesContent = env
-propertiesContent.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLPropertyAsMethodParametersStrategy
+info.type = INNER
+
+propertiesContent = propertiesContent
+#propertiesContent.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLPropertyAsMethodParametersStrategy
 
 # Promoted Builds requires injected XML to combine disparate XML files
 root = root


### PR DESCRIPTION
## Ticket

[JIRA-2961](https://jira.tinyspeck.com/browse/BUILD-2961)

## Overview



## Testing

Test XML Used:
```
<?xml version="1.1" encoding="UTF-8" standalone="no"?><project>
  <actions/>
  <description>Test</description>
  <keepDependencies>false</keepDependencies>
  <buildWrappers>
    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.18"/>
    <EnvInjectBuildWrapper plugin="envinject@2.866.v5c0403e3d4df">
      <info>
        <propertiesContent>TRIGGERED_BY=${triggered_by}</propertiesContent>
        <secureGroovyScript plugin="script-security@1175.v4b_d517d6db_f0">
          <script/>
          <sandbox>true</sandbox>
        </secureGroovyScript>
        <loadFilesFromMaster>false</loadFilesFromMaster>
      </info>
    </EnvInjectBuildWrapper>
</project>
```

DSL Output:
```
job("EKM_rspec_tests") {
	description("Test")
	keepDependencies(false)
	wrappers {
		timestamps()
		EnvInjectBuildWrapper {
			info {
				propertiesContent("TRIGGERED_BY=\${triggered_by}")
				secureGroovyScript {
					script()
					sandbox(true)
				}
				loadFilesFromMaster(false)
			}
		}
	}
}


No untranslated tag! Fit for moving
```
