### PR TITLE
BUILD-2959-pipelineTriggers property

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -44,7 +44,6 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("canRoam");
 		propertiesToBeSkipped.add("sandbox");
 		propertiesToBeSkipped.add("operationList");
-		propertiesToBeSkipped.add("spec");
 		propertiesToBeSkipped.add("caseSensitive");
 		propertiesToBeSkipped.add("EnvInjectPasswordWrapper");
 		propertiesToBeSkipped.add("followSymlinks");

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -893,6 +893,13 @@ au.com.rayh.XCodeBuilder.interpretTargetAsRegEx = interpretTargetAsRegEx
 
 au.com.rayh.XCodeBuilder.ipaManifestPlistUrl = ipaManifestPlistUrl
 
+org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty = pipelineTriggers
+org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty.type = OBJECT
+
+org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty.triggers.hudson.triggers.TimerTrigger = cron
+org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty.triggers.hudson.triggers.TimerTrigger.type = OBJECT
+org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty.triggers.hudson.triggers.TimerTrigger.spec = spec
+
 triggers = triggers
 triggers.type = OBJECT
 


### PR DESCRIPTION
## Ticket

[JIRA-2959](https://jira.tinyspeck.com/browse/BUILD-2959)

## Overview
Used [pipelineTriggers](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.properties.PropertiesContext.pipelineTriggers) in the api viewer as a reference. 
In the context of pipelineTriggers, cron is an object that contains the string value, spec:
<img width="500" alt="Screen Shot 2022-11-09 at 2 31 53 PM" src="https://user-images.githubusercontent.com/112515811/200956321-611b2ea3-0a5d-4004-8b09-bfcb662db507.png">


 There is also another format under [triggers](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.jobs.FreeStyleJob.triggers) that is not nested: 
<img width="500" alt="Screen Shot 2022-11-09 at 2 30 23 PM" src="https://user-images.githubusercontent.com/112515811/200956077-db1be524-fd2d-4754-b67a-85b5e99eefc0.png">
This is currently in the plugin as: 
```
hudson.triggers.TimerTrigger = INNER
hudson.triggers.TimerTrigger.spec = cron
```

I used the specific path of the nested nodes (PipelineTriggersJobProperty -> triggers -> hudson.triggers.TimerTrigger) when adding pipelineTriggers in order to retain both . 

## Testing
XML and DSL shortened for brevity

Test XML Used:

```
<flow-definition plugin="workflow-job@2.9">
    <actions />
    <description>Test pipeline</description>
    <keepDependencies>false</keepDependencies>
    <properties>
        <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
            <triggers>
                <hudson.triggers.TimerTrigger>
                    <spec>H 19 * * *</spec>
                </hudson.triggers.TimerTrigger>
            </triggers>
        </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
    </properties>
    <triggers>
        <hudson.triggers.TimerTrigger>
            <spec>0 22 * * * </spec>
        </hudson.triggers.TimerTrigger>
    </triggers>
</flow-definition>
```

DSL Output:
```
pipelineJob("test") {
	description("Test pipeline")
	keepDependencies(false)
	properties {
		pipelineTriggers {
			triggers {
				cron {
					spec("H 19 * * *")
				}
			}
		}
	}
	triggers {
		cron("0 22 * * *")
	}
}
```
