### PR TITLE
BUILD-2983-Condition attribute within buildTriggerConfig & singleConditionalBuilder

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -57,6 +57,8 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("unstableReturn");
 		propertiesToBeSkipped.add("ignoreMissing");
 		propertiesToBeSkipped.add("activeProcessNames");
+		propertiesToBeSkipped.add("ordinal");
+		propertiesToBeSkipped.add("color");
 
 		try {
 			initProperties();

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -282,6 +282,7 @@ id.enclosing_tag = permalink
 hudson.plugins.copyartifact.CopyArtifact.selector.buildNumber = buildNumber
 hudson.plugins.copyartifact.CopyArtifact.selector.buildNumber.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLEnclosedObjectStrategy
 buildNumber.enclosing_tag = specific
+buildNumberEnclosed = buildNumber
 
 hudson.plugins.copyartifact.CopyArtifact.selector.allowUpstreamDependencies = allowUpstreamDependencies
 allowUpstreamDependenciesEnclosed = allowUpstreamDependencies
@@ -727,6 +728,28 @@ hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.type = O
 hudson.plugins.parameterizedtrigger.BooleanParameters = INNER
 
 hudson.plugins.parameterizedtrigger.BooleanParameterConfig = booleanParam
+
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder = singleConditionalBuilder
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.type = OBJECT
+
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition = condition
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition.type = OBJECT
+
+worstResult = worstResult
+worstResult.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLEnclosedObjectStrategy
+worstResult.enclosing_tag = statusCondition
+worstResultEnclosed = worstResult
+worstResult.name = name
+worstResult.name.type = PARAMETER
+
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition.bestResult.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLEnclosedObjectStrategy
+bestResult.enclosing_tag = statusCondition
+bestResultEnclosed = bestResult
+bestResult.name = name
+bestResult.name.type = PARAMETER
+
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition.runner = runner
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition.runner.type = OBJECT
 
 value = value
 value.type = PARAMETER

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -427,6 +427,7 @@ depth = depth
 honorRefspec = honorRefspec
 
 triggerWithNoParameters = triggerWithNoParameters
+triggerFromChildProjects = triggerFromChildProjects
 
 buildWrappers = wrappers
 buildWrappers.type = OBJECT
@@ -698,6 +699,28 @@ unstableThreshold = unstable
 
 failureThreshold = failure
 
+hudson.plugins.parameterizedtrigger.BuildTrigger = buildTrigger
+hudson.plugins.parameterizedtrigger.BuildTrigger.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.BuildTrigger.configs = configs
+hudson.plugins.parameterizedtrigger.BuildTrigger.configs.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.BuildTriggerConfig = buildTriggerConfig
+hudson.plugins.parameterizedtrigger.BuildTriggerConfig.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs = configs
+hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters = predefinedBuildParameters
+hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.properties = properties
+
+hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.textParamValueOnNewLine = textParamValueOnNewLine
+
+hudson.plugins.parameterizedtrigger.BuildTriggerConfig.condition = condition
+hudson.plugins.parameterizedtrigger.BuildTriggerConfig.projects = projects
+
 hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs = parameters
 hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.type = OBJECT
 
@@ -709,7 +732,6 @@ value = value
 value.type = PARAMETER
 
 hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters = predefinedProps
-
 hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.properties = properties
 hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.properties.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLStringAsArrayStrategy
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -748,9 +748,6 @@ bestResultEnclosed = bestResult
 bestResult.name = name
 bestResult.name.type = PARAMETER
 
-org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition.runner = runner
-org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition.runner.type = OBJECT
-
 value = value
 value.type = PARAMETER
 


### PR DESCRIPTION
## Ticket

[JIRA-2983](https://jira.tinyspeck.com/browse/BUILD-2983)

## Overview
Adds the `condition` property from the missing attribute tracker. This was present in the config.xml's in two contexts:  as a string in [buildTriggerConfig](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.buildTrigger) :
```
<hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.45">
      <configs>
        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
          <configs>
            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
              <properties>ACT_BUILD_URL=$BUILD_URL</properties>
              <textParamValueOnNewLine>false</textParamValueOnNewLine>
            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
          </configs>
          <projects>NotificationACT</projects>
          <condition>FAILED_OR_BETTER</condition>
          <triggerWithNoParameters>false</triggerWithNoParameters>
          <triggerFromChildProjects>false</triggerFromChildProjects>
        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
      </configs>
</hudson.plugins.parameterizedtrigger.BuildTrigger>  
```
and as an object in [singleConditionalBuilder](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/hudson.tasks.BuildStep$$List.singleConditionalBuilder):
```
<condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition" plugin="run-condition@1.5">
     <worstResult>           
          <name>SUCCESS</name>
          <ordinal>0</ordinal>           
          <color>BLUE</color>           
          <completeBuild>true</completeBuild>         
     </worstResult>         
     <bestResult>           
          <name>SUCCESS</name>           
          <ordinal>0</ordinal>           
          <color>BLUE</color>           
          <completeBuild>true</completeBuild>         
     </bestResult>       
</condition>  
```
Added support for `condition` and all other properties within these except for `ordinal` and `color` which are not supported

## Testing

Test XML Used:
```
<project>
    <actions />
    <description>Test</description>
    <keepDependencies>false</keepDependencies>
    <builders>
        <hudson.tasks.Shell>
            <command>Test</command>
            <configuredLocalRules />
            <unstableReturn>128</unstableReturn>
        </hudson.tasks.Shell>
        <org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder plugin="conditional-buildstep@1.4.2">
            <condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition" plugin="run-condition@1.5">
                <worstResult>
                    <name>SUCCESS</name>
                    <ordinal>0</ordinal>
                    <color>BLUE</color>
                    <completeBuild>true</completeBuild>
                </worstResult>
                <bestResult>
                    <name>SUCCESS</name>
                    <ordinal>0</ordinal>
                    <color>BLUE</color>
                    <completeBuild>true</completeBuild>
                </bestResult>
            </condition>
        </org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder>
    </builders>
    <publishers>
        <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.45">
            <configs>
                <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
                    <configs>
                        <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
                            <properties>SHA=${SHA}</properties>
                            <textParamValueOnNewLine>false</textParamValueOnNewLine>
                        </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
                    </configs>
                    <projects>Test</projects>
                    <condition>SUCCESS</condition>
                    <triggerWithNoParameters>false</triggerWithNoParameters>
                    <triggerFromChildProjects>false</triggerFromChildProjects>
                </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
            </configs>
        </hudson.plugins.parameterizedtrigger.BuildTrigger>
    </publishers>
</project>
```

DSL Output:
```
job("test") {
	description("Test")
	keepDependencies(false)
	steps {
		shell("Test")
		singleConditionalBuilder {
			condition {
				statusCondition {
					worstResult("SUCCESS")
					bestResult("SUCCESS")
				}
			}
		}
	}
	publishers {
		buildTrigger {
			configs {
				buildTriggerConfig {
					configs {
						predefinedBuildParameters {
							properties("SHA=\${SHA}")
							textParamValueOnNewLine(false)
						}
					}
					projects("Test")
					condition("SUCCESS")
					triggerWithNoParameters(false)
					triggerFromChildProjects(false)
				}
			}
		}
	}
}
```

