### PR TITLE
BUILD-2961-sandbox and envInject properties

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -42,10 +42,8 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("submoduleCfg");
 		propertiesToBeSkipped.add("doGenerateSubmoduleConfigurations");
 		propertiesToBeSkipped.add("canRoam");
-		propertiesToBeSkipped.add("sandbox");
 		propertiesToBeSkipped.add("operationList");
 		propertiesToBeSkipped.add("caseSensitive");
-		propertiesToBeSkipped.add("EnvInjectPasswordWrapper");
 		propertiesToBeSkipped.add("followSymlinks");
 		propertiesToBeSkipped.add("completeBuild");
 		propertiesToBeSkipped.add("externalDelete");

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -784,10 +784,26 @@ scriptPath = scriptPath
 EnvInjectJobProperty = environmentVariables
 EnvInjectJobProperty.type = OBJECT
 
-EnvInjectBuildWrapper = environmentVariables
+EnvInjectBuildWrapper = envInjectBuildWrapper
 EnvInjectBuildWrapper.type = OBJECT
 
-EnvInjectBuildWrapper.info.loadFilesFromMaster = INNER
+EnvInjectBuildWrapper.info = info
+EnvInjectBuildWrapper.info.type = OBJECT
+
+propertiesContent = propertiesContent
+EnvInjectPasswordWrapper = envInjectPasswordWrapper
+EnvInjectPasswordWrapper.type = OBJECT
+
+injectGlobalPasswords = injectGlobalPasswords
+maskPasswordParameters = maskPasswordParameters
+EnvInjectPasswordWrapper.passwordEntries = passwordEntries
+EnvInjectPasswordWrapper.passwordEntries.type = OBJECT
+
+EnvInjectPasswordWrapper.passwordEntries.EnvInjectPasswordEntry = envInjectPasswordEntry
+EnvInjectPasswordWrapper.passwordEntries.EnvInjectPasswordEntry.type = OBJECT
+
+EnvInjectPasswordEntry.name = name
+EnvInjectPasswordEntry.value = password
 
 EnvInjectJobProperty.keepBuildVariables = keepBuildVariables
 
@@ -800,16 +816,16 @@ contributors.type = OBJECT
 
 loadFilesFromMaster = loadFilesFromMaster
 
-secureGroovyScript = INNER
+secureGroovyScript = secureGroovyScript
+secureGroovyScript.type = OBJECT
 
-secureGroovyScript.script = groovy
-
-EnvInjectBuildWrapper.info = INNER
+secureGroovyScript.script = script
+sandbox = sandbox
 
 info = INNER
 
-propertiesContent = env
-propertiesContent.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLPropertyAsMethodParametersStrategy
+#propertiesContent = env
+#propertiesContent.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLPropertyAsMethodParametersStrategy
 
 # Promoted Builds requires injected XML to combine disparate XML files
 root = root

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -824,9 +824,6 @@ sandbox = sandbox
 
 info = INNER
 
-#propertiesContent = env
-#propertiesContent.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLPropertyAsMethodParametersStrategy
-
 # Promoted Builds requires injected XML to combine disparate XML files
 root = root
 root.type = INNER


### PR DESCRIPTION
## Ticket

[JIRA-2961](https://jira.tinyspeck.com/browse/BUILD-2961)

## Overview
Adding `sandbox` property from missing attribute [tracker](https://docs.google.com/spreadsheets/d/10VKnXEpSh_WQb64uG2OjEvF7anuU6fUSkIU5sJ1tG20/edit#gid=0).  This is found under `secureGroovyScript` within [envInjectBuildWrapper](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.envInjectBuildWrapper). `envInjectBuildWrapper` is currently in the plugin using [this](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.environmentVariables) format; however all occurrences within the config.xml files on Jenkins Tinyspeck match the dynamic DSL. 

`sandbox` and `EnvInjectPasswordWrapper` were under properties to be skipped; however, because they are supported in the Tinyspeck api viewer, I added support for them. 

`propertiesContent` was using a custom class (only occurrence of custom class) that splits the string into a KEY and VALUE. Using the dynamic DSL, this is not needed for propertiesContent. 


## Testing

Test XML Used:
```
<project>
    <actions />
    <description>Test</description>
    <keepDependencies>false</keepDependencies>
    <buildWrappers>
        <EnvInjectBuildWrapper plugin="envinject@2.866.v5c0403e3d4df">
            <info>
                <propertiesContent>TRIGGERED_BY=${triggered_by}</propertiesContent>
                <secureGroovyScript plugin="script-security@1175.v4b_d517d6db_f0">
                    <script />
                    <sandbox>true</sandbox>
                </secureGroovyScript>
                <loadFilesFromMaster>false</loadFilesFromMaster>
            </info>
        </EnvInjectBuildWrapper>
        <EnvInjectPasswordWrapper plugin="envinject@2.866.v5c0403e3d4df">
            <injectGlobalPasswords>false</injectGlobalPasswords>
            <maskPasswordParameters>true</maskPasswordParameters>
            <passwordEntries>
                <EnvInjectPasswordEntry>
                    <name>CY_RECORD_KEY</name>
                    <value>{test}</value>
                </EnvInjectPasswordEntry>
                <EnvInjectPasswordEntry>
                    <name>TSAUTH_TOKEN_STAGING</name>
                    <value>{test}</value>
                </EnvInjectPasswordEntry>
            </passwordEntries>
        </EnvInjectPasswordWrapper>
        <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@2.2.0">
            <template>#${BUILD_NUMBER}</template>
            <runAtStart>true</runAtStart>
            <runAtEnd>true</runAtEnd>
        </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
    </buildWrappers>
</project>
```

DSL Output:
```
job("test") {
	description("Test")
	keepDependencies(false)
	wrappers {
		envInjectBuildWrapper {
			info {
				propertiesContent("TRIGGERED_BY=\${triggered_by}")
				secureGroovyScript {
					script()
					sandbox(true)
				}
				loadFilesFromMaster(false)
			}
		}
		envInjectPasswordWrapper {
			injectGlobalPasswords(false)
			maskPasswordParameters(true)
			passwordEntries {
				envInjectPasswordEntry {
					name("CY_RECORD_KEY")
					password("{test}")
				}
				envInjectPasswordEntry {
					name("TSAUTH_TOKEN_STAGING")
					password("{test}")
				}
			}
		}
		buildNameSetter {
			template("#\${BUILD_NUMBER}")
			runAtStart(true)
			runAtEnd(true)
		}
	}
}


No untranslated tag! Fit for moving
```
