### PR TITLE
BUILD-3027-convert branch name correctly and correct parameterDefinitionsProperty

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -56,8 +56,7 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("ordinal");
 		propertiesToBeSkipped.add("color");
 		propertiesToBeSkipped.add("activeProcessNames");
-		propertiesToBeSkipped.add("ordinal");
-		propertiesToBeSkipped.add("color");
+		propertiesToBeSkipped.add("trim");
 
 		try {
 			initProperties();

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -315,24 +315,23 @@ hudson.plugins.copyartifact.CopyArtifactPermissionProperty.type = OBJECT
 
 projectNameList = projectNames
 
-parameterDefinitions = parameterDefinitions
-parameterDefinitions.type = OBJECT
+hudson.model.ParametersDefinitionProperty.parameterDefinitions = INNER
 
-hudson.model.StringParameterDefinition = stringParam
-hudson.model.StringParameterDefinition.type = OBJECT
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.StringParameterDefinition = stringParam
+hudson.model.StringParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
 hudson.model.TextParameterDefinition = textParam
 hudson.model.TextParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
-name = name
+name = PARAM_NAME
+name.type = PARAMETER
 
-defaultValue = defaultValue
+defaultValue = PARAM_DEFAULT_VALUE
+defaultValue.type = PARAMETER
 
-description = description
+description = PARAM_DESCRIPTION
+description.type = PARAMETER
 
-trim = trim
-
-pre = pre
 pre.type = PARAMETER
 
 com.cloudbees.plugins.credentials.CredentialsParameterDefinition = credentialsParam
@@ -350,9 +349,10 @@ credentialType = type
 credentialType.type = PARAMETER
 
 hudson.model.ChoiceParameterDefinition = choiceParam
-hudson.model.ChoiceParameterDefinition.type = OBJECT
+hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
 
-choices = choices
+choices = INNER
+choices.type = INNER
 
 a = a
 a.type = ARRAY
@@ -361,7 +361,7 @@ string = string
 string.type = PARAMETER
 
 hudson.model.BooleanParameterDefinition = booleanParam
-hudson.model.BooleanParameterDefinition.type = OBJECT
+hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
 scm = scm
 scm.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLHiddenTagStrategy
@@ -402,6 +402,9 @@ hudson.plugins.git.UserRemoteConfig.credentialsId = credentials
 branches = INNER
 
 hudson.plugins.git.BranchSpec = branch
+
+scm.branches.hudson.plugins.git.BranchSpec.name = name
+scm.branches.hudson.plugins.git.BranchSpec.name.type = PARAMETER
 
 extensions = extensions
 extensions.type = OBJECT


### PR DESCRIPTION
## Ticket

[JIRA-3027](https://jira.tinyspeck.com/browse/BUILD-3027)

## Overview
`branch` was incorrectly being translated to an object `branch({
	name("*/master")
     }) ` and should look like `branch("*/master")`. 

There is another property with the `name` variable, which is  found within `parameterDefinitionsProperty`. This was originally using a custom class and any job containing that attribute was not being converted at all. See this [PR](https://github.com/tinyspeck/xml-job-to-job-dsl-plugin/pull/28). Using the full path of the xml when declaring them in translator.properties and using the original custom class corrected the issue and both are now translating correctly. 

References for [stringParam](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.BuildParametersContext.stringParam),[ booleanParam ](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.BuildParametersContext.booleanParam), and [choiceParam](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.BuildParametersContext.choiceParam)

## Testing

Test XML Used:
```
<project>
    <actions/>
    <description>Mirror GHE slack/docs in https://github.com/tinyspeck/InternalDocs.git</description>
    <keepDependencies>false</keepDependencies>
    <properties>
        <hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.ChoiceParameterDefinition>
                    <name>DEPLOY_GROUP</name>
                    <description>Group of hosts to upgrade: Testing</description>
                    <choices class="java.util.Arrays$ArrayList">
                        <a class="string-array">
                            <string>role:notraffic</string>
                            <string>dogfood:all</string>
                            <string>role:pepper</string>
                            <string>role:heavy_pepper</string>
                            <string>smart</string>
                        </a>
                    </choices>
                </hudson.model.ChoiceParameterDefinition>
                <hudson.model.BooleanParameterDefinition>
                    <name>DRY_RUN</name>
                    <description>Make this a dry run that shows the list of hosts that would be upgraded</description>
                    <defaultValue>true</defaultValue>
                </hudson.model.BooleanParameterDefinition>
                <hudson.model.StringParameterDefinition>
                    <name>DEPLOY_HOSTS</name>
                    <description>Deploy to specified hosts</description>
                    <trim>false</trim>
                </hudson.model.StringParameterDefinition>
            </parameterDefinitions>
        </hudson.model.ParametersDefinitionProperty>
    </properties>
    <scm class="hudson.plugins.git.GitSCM" plugin="git@4.11.1">
        <configVersion>2</configVersion>
        <userRemoteConfigs>
            <hudson.plugins.git.UserRemoteConfig>
                <url>git@slack-github.com:slack/docs.git</url>
                <credentialsId>Jenkins-GHE</credentialsId>
            </hudson.plugins.git.UserRemoteConfig>
            <hudson.plugins.git.UserRemoteConfig>
                <url>git@github.com:tinyspeck/InternalDocs.git</url>
                <credentialsId>dd604775-4999-432f-bba0-f126f89cfdd1</credentialsId>
            </hudson.plugins.git.UserRemoteConfig>
        </userRemoteConfigs>
        <branches>
            <hudson.plugins.git.BranchSpec>
                <name>*/master</name>
            </hudson.plugins.git.BranchSpec>
        </branches>
        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
        <submoduleCfg class="empty-list"/>
        <extensions/>
    </scm>
```

DSL Output:
```
job("test") {
	description("Mirror GHE slack/docs in https://github.com/tinyspeck/InternalDocs.git")
	keepDependencies(false)
	properties {
		parameters {
			choiceParam("DEPLOY_GROUP", ["role:notraffic", "dogfood:all", "role:pepper", "role:heavy_pepper", "smart"], "Group of hosts to upgrade: Testing")
			booleanParam("DRY_RUN", true, "Make this a dry run that shows the list of hosts that would be upgraded")
			stringParam("DEPLOY_HOSTS", "Deploy to specified hosts")
		}
	}
	scm {
		git {
			remote {
				github("slack/docs", "ssh")
				credentials("Jenkins-GHE")
			}
			remote {
				github("tinyspeck/InternalDocs", "ssh")
				credentials("dd604775-4999-432f-bba0-f126f89cfdd1")
			}
			branch("*/master")
		}
	}
```
