### PR TITLE
BUILD-3033-ansiColorBuildWrapper property

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -443,6 +443,10 @@ buildWrappers.type = OBJECT
 
 org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper = INNER
 
+hudson.plugins.ansicolor.AnsiColorBuildWrapper = ansiColorBuildWrapper
+hudson.plugins.ansicolor.AnsiColorBuildWrapper.type = OBJECT
+colorMapName = colorMapName
+
 bindings = credentialsBinding
 bindings.type = OBJECT
 


### PR DESCRIPTION
## Ticket

[JIRA-3033](https://jira.tinyspeck.com/browse/BUILD-3033)

## Overview
Adds ansiColorBuildWrapper and colorMapName, found under wrappers

## Testing

XML shortened for brevity.

Test XML Used:
```
<buildWrappers>
        <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@1.0.2">
            <colorMapName>xterm</colorMapName>
        </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
</buildWrappers>
```

DSL Output:
```
wrappers {
		ansiColorBuildWrapper {
			colorMapName("xterm")
		}
```
