### PR TITLE
preBuildCleanup property

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -57,6 +57,7 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("color");
 		propertiesToBeSkipped.add("activeProcessNames");
 		propertiesToBeSkipped.add("trim");
+		propertiesToBeSkipped.add("disableDeferredWipeout");
 
 		try {
 			initProperties();

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -609,6 +609,9 @@ stopOnFailure = stopOnFailure
 buildSteps = buildSteps
 buildSteps.type = OBJECT
 
+hudson.plugins.promoted__builds.PromotionProcess.buildSteps = steps
+hudson.plugins.promoted__builds.PromotionProcess.buildSteps.type = OBJECT
+
 markBuildUnstable = markBuildUnstable
 
 scriptOnlyIfSuccess = onlyIfBuildSucceeds
@@ -643,13 +646,12 @@ cleanWhenNotBuilt = cleanWhenNotBuilt
 cleanWhenSuccess = cleanWhenSuccess
 cleanWhenUnstable = cleanWhenUnstable
 deleteCommand = deleteCommand
-deleteDirectories = deleteDirectories
+deleteDirs = deleteDirectories
 excludePattern = excludePattern
 failBuildWhenCleanupFails = failBuildWhenCleanupFails
 includePattern = includePattern
 notFailBuild = notFailBuild
 patterns.type = OBJECT
-disableDeferredWipeout = disableDeferredWipeout
 cleanupMatrixParent = cleanupMatrixParent
 externalDelete = externalDelete
 skipWhenFailed = skipWhenFailed
@@ -695,7 +697,6 @@ hudson.plugins.timestamper.TimestamperBuildWrapper = timestamps
 
 hudson.plugins.ws__cleanup.PreBuildCleanup = preBuildCleanup
 hudson.plugins.ws__cleanup.PreBuildCleanup.type = OBJECT
-deleteDirs = deleteDirs
 cleanupParameter = cleanupParameter
 
 com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper = sshAgent

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -609,7 +609,7 @@ stopOnFailure = stopOnFailure
 buildSteps = buildSteps
 buildSteps.type = OBJECT
 
-hudson.plugins.promoted__builds.PromotionProcess.buildSteps = steps
+hudson.plugins.promoted__builds.PromotionProcess.buildSteps = actions
 hudson.plugins.promoted__builds.PromotionProcess.buildSteps.type = OBJECT
 
 markBuildUnstable = markBuildUnstable
@@ -653,7 +653,6 @@ includePattern = includePattern
 notFailBuild = notFailBuild
 patterns.type = OBJECT
 cleanupMatrixParent = cleanupMatrixParent
-externalDelete = externalDelete
 skipWhenFailed = skipWhenFailed
 patterns = patterns
 hudson.plugins.ws__cleanup.WsCleanup.patterns.pattern = pattern

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -609,9 +609,6 @@ stopOnFailure = stopOnFailure
 buildSteps = buildSteps
 buildSteps.type = OBJECT
 
-hudson.plugins.promoted__builds.PromotionProcess.buildSteps = actions
-hudson.plugins.promoted__builds.PromotionProcess.buildSteps.type = OBJECT
-
 markBuildUnstable = markBuildUnstable
 
 scriptOnlyIfSuccess = onlyIfBuildSucceeds


### PR DESCRIPTION
## Ticket
[JIRA-3095](https://jira.tinyspeck.com/browse/BUILD-3095)

## Overview
This PR targets the preBuildCleanup and cleanWs properties. The [docs](https://github.com/jenkinsci/ws-cleanup-plugin) for Workspace Cleanup explain that for freestyle jobs, the plugin provides a build wrapper (Delete workspace before build starts) and a post build step (Delete workspace when build is done).  [preBuildCleanup](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.preBuildCleanup) cleans before the build while [cleanWs](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.preBuildCleanup) cleans after the build. 

The XML within the config.xml files for jobs looks like: 
```
<buildWrappers>
     <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.43">
     <deleteDirs>false</deleteDirs>
     <cleanupParameter/>
     <externalDelete/>
     <disableDeferredWipeout>false</disableDeferredWipeout>
     </hudson.plugins.ws__cleanup.PreBuildCleanup>
</buildWrappers>
```

Because the preBuildCleanup tag is within `buildWrappers`, the properties `externalDelete` and `disableDeferredWipeout` should not render as they are not supported. externalDelete was already listed under PropertiesToBeSkipped and disableDeferredWipeout was added for this PR. 

## Testing
A test job was [successfully](https://jenkins-tinyspeck-bedrock-dev.tinyspeck.com/job/Job_DSL_Seed/2439/) built using the changes to `steps` and `preBuildCleanup` 

<img width="394" alt="Screen Shot 2022-12-22 at 4 32 01 PM" src="https://user-images.githubusercontent.com/112515811/209229946-13df82ef-35e9-4271-8c89-d5cd6b40f34a.png">

DSL Output:
```
wrappers {
		preBuildCleanup {
			deleteDirectories(false)
			cleanupParameter()
		}
		timestamps()
```
