### PR TITLE
BUILD-3088 correct url for repository url

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -407,8 +407,7 @@ hudson.plugins.git.UserRemoteConfig.type = OBJECT
 
 hudson.plugins.git.UserRemoteConfig.name = name
 
-url = github
-url.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLGitHubMethodStrategy
+url = url
 
 github.url = github
 github.url.type = PARAMETER


### PR DESCRIPTION
## Ticket

[JIRA-3088](https://jira.tinyspeck.com/browse/BUILD-3088)

## Overview
The url is being rendered incorrectly once the job is built by the seedjob. It's using git@github.com. `url` is being set to `github` and is currently using a custom class which takes in the url string and should create the url based on the parameters listed in the DSL [api viewer](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.scm.RemoteContext.github) ; however, this is causing an error in the created job. Using `url` is [supported](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.scm.GitContext.remote) sets the remote url correctly. 

A correct repository URL:
<img width="500" alt="Screen Shot 2022-12-21 at 10 47 37 AM" src="https://user-images.githubusercontent.com/112515811/208951828-a00f7409-dab7-452a-ae23-e76318f80921.png">

Current output:
<img width="500" alt="Screen Shot 2022-12-21 at 10 47 49 AM" src="https://user-images.githubusercontent.com/112515811/208952032-3c3a9cb7-cd5b-4888-9e60-06d4c54db045.png">

This url is also being added to the repository browser field, when it should be set to Auto as seen in the original jobs:  

<img width="500" alt="Screen Shot 2022-12-21 at 10 47 07 AM" src="https://user-images.githubusercontent.com/112515811/208952854-a0bd365c-853c-4e80-b740-61d8ed087989.png">

<img width="500" alt="Screen Shot 2022-12-21 at 10 47 22 AM" src="https://user-images.githubusercontent.com/112515811/208953234-c9173660-5884-4261-b15f-879803ffb881.png">

The GitHub Project field and project url are also being created in the job which, when compared to the original job, should be unchecked 

<img width="643" alt="Screen Shot 2022-12-21 at 10 49 30 AM" src="https://user-images.githubusercontent.com/112515811/208953847-93817edd-f652-4852-84d5-e68c8a033492.png">


## Testing
A test job was successfully built with the correct url displaying.

Test XML Used:
```
<scm class="hudson.plugins.git.GitSCM" plugin="git@4.12.1">
    <configVersion>2</configVersion>
    <userRemoteConfigs>
      <hudson.plugins.git.UserRemoteConfig>
        <url>ssh://git@slack-github.com/slack/lucene-solr.git</url>
        <credentialsId>Jenkins-GHE</credentialsId>
      </hudson.plugins.git.UserRemoteConfig>
    </userRemoteConfigs>
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>*/branch_8_11_2_slack_prod</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
    <submoduleCfg class="empty-list"/>
    <extensions/>
  </scm>
```

DSL Output:
Before the change the DSL used to create this part of the job was:
```
scm {
		git {
			remote {
				github("ssh://git@slack-github.com/slack/lucene-solr.git")
				credentials("Jenkins-GHE")
			}
			branch("*/branch_8_11_2_slack_prod")
		}
	}
```
After change:
```
scm {
		git {
			remote {
				url("ssh://git@slack-github.com/slack/lucene-solr.git")
				credentials("Jenkins-GHE")
			}
			branch("*/branch_8_11_2_slack_prod")
		}
	}
```
