### PR TITLE
git extension properties causing job errors 

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -58,6 +58,7 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("activeProcessNames");
 		propertiesToBeSkipped.add("isVisible");
 		propertiesToBeSkipped.add("trim");
+		propertiesToBeSkipped.add("shallow");
 
 		try {
 			initProperties();

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -392,11 +392,12 @@ git.type = OBJECT
 doGenerateSubmoduleConfigurations=doGenerateSubmoduleConfigurations
 doGenerateSubmoduleConfigurations.type=OBJECT
 
-hudson.plugins.git.extensions.impl.SubmoduleOption = submoduleOption
+hudson.plugins.git.extensions.impl.SubmoduleOption = submoduleOptions
 hudson.plugins.git.extensions.impl.SubmoduleOption.type = OBJECT
-disableSubmodules = disableSubmodules
-recursiveSubmodules = recursiveSubmodules
-trackingSubmodules = trackingSubmodules
+
+disableSubmodules = disable
+recursiveSubmodules = recursive
+trackingSubmodules = tracking
 parentCredentials = parentCredentials
 threads = threads
 
@@ -441,9 +442,9 @@ deleteUntrackedNestedRepositories = deleteUntrackedNestedRepositories
 
 hudson.plugins.git.extensions.impl.CheckoutOption = cloneOptions
 hudson.plugins.git.extensions.impl.CheckoutOption.type = OBJECT
-timeout=timeout
+timeout = timeout
 
-hudson.plugins.git.extensions.impl.CloneOption = cloneOption
+hudson.plugins.git.extensions.impl.CloneOption = cloneOptions
 hudson.plugins.git.extensions.impl.CloneOption.type = OBJECT
 
 shallow = shallow


### PR DESCRIPTION
## Ticket

[JIRA-3102](https://jira.tinyspeck.com/browse/BUILD-3102)

## Overview
When testing jobs, the properties under gitExtension: cloneOption and submoduleOption are causing failures. They are converting as:
```
extensions {
				cloneOption {
					shallow(false)
					noTags(false)
					reference()
					honorRefspec(false)
				}
				submoduleOption {
					disableSubmodules(false)
					recursiveSubmodules(true)
					trackingSubmodules(false)
					reference()
					parentCredentials(false)
					shallow(false)
				}
``` 
If a value isn't in the xml then it is not rendered, and empty tags have no value, which is causing a failure. Leaving unused methods off also causes an error and the job fails to build.  
`javaposse.jobdsl.plugin.structs.DescribableContext.reference() is applicable for argument types: () values: [] `
`ERROR: (unknown source) the following options are required and must be specified: timeout ` 

There is an alternative to the dynamic dsl that differs slightly: [cloneOptions](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.scm.GitExtensionContext.cloneOptions) and [submoduleOptions](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.scm.GitExtensionContext.submoduleOptions)

Mapping the xml for this syntax, the dsl looks like: 
```
git {
			remote {
				url("git@slack-github.com:slack/apache2.git")
				credentials("Jenkins-GHE")
			}
			branch("*/main")
			extensions {
				cloneOptions {
					noTags(false)
					reference()
					honorRefspec(false)
				}
				submoduleOptions {
					disable(false)
					recursive(true)
					tracking(false)
					reference()
					parentCredentials(false)
				}
			}
```
The empty methods do not cause an error and the job builds successfully. `shallow` is not supported for submoduleOptions so it was added to properties to be skipped. 

## Testing
This was tested by converting a sample job and comparing to the original, which built [successfully](https://jenkins-tinyspeck-bedrock-dev.tinyspeck.com/job/Job_DSL_Seed/2387/) with the same configuration.

<img width="400" alt="Screen Shot 2022-12-21 at 5 41 00 PM" src="https://user-images.githubusercontent.com/112515811/209016426-aa470a3d-9f60-43b1-85bd-ef6d1ca594fb.png">


Test XML Used:
```
<extensions>
            <hudson.plugins.git.extensions.impl.CloneOption>
                <shallow>false</shallow>
                <noTags>false</noTags>
                <reference/>
                <honorRefspec>false</honorRefspec>
            </hudson.plugins.git.extensions.impl.CloneOption>
            <hudson.plugins.git.extensions.impl.SubmoduleOption>
                <disableSubmodules>false</disableSubmodules>
                <recursiveSubmodules>true</recursiveSubmodules>
                <trackingSubmodules>false</trackingSubmodules>
                <reference/>
                <parentCredentials>false</parentCredentials>
                <shallow>false</shallow>
            </hudson.plugins.git.extensions.impl.SubmoduleOption>
        </extensions>
```
