### PR TITLE
[BUILD-3087] Parameters should not be nested under properties

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -182,6 +182,27 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 				notTranslatedList.addAll(strategy.getNotTranslatedList());
 			}
 		}
+
+		if (descriptor.getAddedProperties() == null) {
+			return;
+		}
+
+		List<PropertyDescriptor> addedProperties = descriptor.getAddedProperties();
+		Iterator<PropertyDescriptor> addedIterator = addedProperties.iterator();
+
+		while (addedIterator.hasNext()) {
+			PropertyDescriptor propertyDescriptor = addedIterator.next();
+
+			if (propertiesToBeSkipped.contains(propertyDescriptor.getName())) {
+				continue;
+			}
+
+			DSLStrategy strategy = getStrategyByPropertyDescriptorType(propertyDescriptor);
+			if (strategy != null) {
+				addChild(strategy);
+				notTranslatedList.addAll(strategy.getNotTranslatedList());
+			}
+		}
 	}
 
 	protected List<PropertyDescriptor> getChildrenOfType(PropertyDescriptor parent, String type) {

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -188,6 +188,8 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 			return;
 		}
 
+		// It is possible for a properties' child or children to try to add more nodes to it
+		// Check for those nodes here and add their strategies as children.
 		List<PropertyDescriptor> addedProperties = descriptor.getAddedProperties();
 		Iterator<PropertyDescriptor> addedIterator = addedProperties.iterator();
 

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLObjectIgnoreParentStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLObjectIgnoreParentStrategy.java
@@ -1,0 +1,92 @@
+package com.adq.jenkins.xmljobtodsl.dsl.strategies.custom;
+import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLObjectStrategy;
+import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DSLObjectIgnoreParentStrategy extends DSLObjectStrategy {
+
+    private final String name;
+    private Boolean ignore = false;
+
+    public DSLObjectIgnoreParentStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name) {
+        this(tabs, propertyDescriptor, name, true);
+        
+        if(propertyDescriptor.getAttributes() == null || !propertyDescriptor.getAttributes().containsKey("ignoredParent")){
+            ignoreParentNode(propertyDescriptor);
+            this.ignore = true;
+        }
+    }
+
+    public DSLObjectIgnoreParentStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name, boolean shouldInitChildren) {
+        super(tabs, propertyDescriptor, name, shouldInitChildren);
+        this.name = name;
+        if(propertyDescriptor.getAttributes() == null || !propertyDescriptor.getAttributes().containsKey("ignoredParent")){
+            ignoreParentNode(propertyDescriptor);
+            this.ignore = true;
+        }
+    }
+
+    private void ignoreParentNode(PropertyDescriptor propertyDescriptor){
+        PropertyDescriptor grandparent = propertyDescriptor.getParent().getParent();
+
+        // Change the current node's attributes to indicate it's been touched already
+        // it'll be processed again in AbstractDSLStrategy
+        propertyDescriptor.addAttribute("ignoredParent", "1");
+        grandparent.addProperty(propertyDescriptor);
+    }
+
+    @Override
+    public String toDSL() {
+        String childrenDSL = getChildrenDSL();
+        if (childrenDSL.isEmpty() || ignore) {
+            return "";
+        }
+
+        if (name != null) {
+            return replaceTabs(String.format(getSyntax("syntax.object_with_name"), name, childrenDSL), getTabs());
+        } else {
+            return replaceTabs(String.format(getSyntax("syntax.object"), childrenDSL), getTabs());
+        }
+    }
+}
+
+//public class DSLObjectIgnoreParentStrategy extends DSLObjectStrategy {
+//
+//    private final String name;
+//
+//    public DSLObjectIgnoreParentStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name, boolean shouldInitChildren) {
+//        super(tabs, propertyDescriptor, name, shouldInitChildren);
+//        this.name = name;
+//
+//        PropertyDescriptor grandparent = propertyDescriptor.getParent().getParent();
+//
+//        // Remove the current node as a child from its parent
+//        List<PropertyDescriptor> siblingProperties = propertyDescriptor.getParent().getProperties();
+//        siblingProperties.remove(propertyDescriptor);
+//        propertyDescriptor.getParent().replaceProperties(siblingProperties);
+//
+//        // Make a new list of children including the current node and its parents' siblings
+//        List<PropertyDescriptor> newChildren = grandparent.getProperties();
+//        newChildren.add(propertyDescriptor);
+//
+//        // Replace the children of the grandparent
+//        grandparent.replaceProperties(newChildren);
+//        initChildren(grandparent);
+//    }
+//
+//    @Override
+//    public String toDSL() {
+//        String childrenDSL = getChildrenDSL();
+//        if (childrenDSL.isEmpty()) {
+//            return "";
+//        }
+//
+//        if (name != null) {
+//            return replaceTabs(String.format(getSyntax("syntax.object_with_name"), name, childrenDSL), getTabs());
+//        } else {
+//            return replaceTabs(String.format(getSyntax("syntax.object"), childrenDSL), getTabs());
+//        }
+//    }
+//}

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLObjectIgnoreParentStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLObjectIgnoreParentStrategy.java
@@ -5,6 +5,12 @@ import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
 import java.util.ArrayList;
 import java.util.List;
 
+/*
+In the case where an XML attribute is nested incorrectly, we can copy the node to the correct "grandparent" and choose to ignore it
+in its current location.
+
+This class does assume the attribute is an object and likely won't work for other attribute types.
+ */
 public class DSLObjectIgnoreParentStrategy extends DSLObjectStrategy {
 
     private final String name;
@@ -51,42 +57,3 @@ public class DSLObjectIgnoreParentStrategy extends DSLObjectStrategy {
         }
     }
 }
-
-//public class DSLObjectIgnoreParentStrategy extends DSLObjectStrategy {
-//
-//    private final String name;
-//
-//    public DSLObjectIgnoreParentStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name, boolean shouldInitChildren) {
-//        super(tabs, propertyDescriptor, name, shouldInitChildren);
-//        this.name = name;
-//
-//        PropertyDescriptor grandparent = propertyDescriptor.getParent().getParent();
-//
-//        // Remove the current node as a child from its parent
-//        List<PropertyDescriptor> siblingProperties = propertyDescriptor.getParent().getProperties();
-//        siblingProperties.remove(propertyDescriptor);
-//        propertyDescriptor.getParent().replaceProperties(siblingProperties);
-//
-//        // Make a new list of children including the current node and its parents' siblings
-//        List<PropertyDescriptor> newChildren = grandparent.getProperties();
-//        newChildren.add(propertyDescriptor);
-//
-//        // Replace the children of the grandparent
-//        grandparent.replaceProperties(newChildren);
-//        initChildren(grandparent);
-//    }
-//
-//    @Override
-//    public String toDSL() {
-//        String childrenDSL = getChildrenDSL();
-//        if (childrenDSL.isEmpty()) {
-//            return "";
-//        }
-//
-//        if (name != null) {
-//            return replaceTabs(String.format(getSyntax("syntax.object_with_name"), name, childrenDSL), getTabs());
-//        } else {
-//            return replaceTabs(String.format(getSyntax("syntax.object"), childrenDSL), getTabs());
-//        }
-//    }
-//}

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/parsers/IDescriptor.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/parsers/IDescriptor.java
@@ -5,4 +5,6 @@ import java.util.List;
 public interface IDescriptor {
     String getName();
     List<PropertyDescriptor> getProperties();
+
+    List<PropertyDescriptor> getAddedProperties();
 }

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/parsers/JobDescriptor.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/parsers/JobDescriptor.java
@@ -12,6 +12,7 @@ public class JobDescriptor implements IDescriptor {
 
     private String name;
     private List<PropertyDescriptor> properties;
+    private List<PropertyDescriptor> addedProperties;
 
     public JobDescriptor(String name, List<PropertyDescriptor> properties) {
         this.name = name;
@@ -25,6 +26,8 @@ public class JobDescriptor implements IDescriptor {
     public List<PropertyDescriptor> getProperties() {
         return properties;
     }
+
+    public List<PropertyDescriptor> getAddedProperties(){ return addedProperties; }
 
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/parsers/PropertyDescriptor.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/parsers/PropertyDescriptor.java
@@ -4,6 +4,8 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.GsonBuilder;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -14,6 +16,8 @@ public class PropertyDescriptor implements IDescriptor {
     private String name;
     private PropertyDescriptor parent;
     private List<PropertyDescriptor> properties;
+
+    private List<PropertyDescriptor> addedProperties;
     private Map<String, String> attributes;
     private String value;
 
@@ -45,6 +49,7 @@ public class PropertyDescriptor implements IDescriptor {
         this.name = name;
         this.value = value;
         this.properties = properties;
+        this.addedProperties = new ArrayList<>();
         this.attributes = attributes;
         this.parent = parent;
     }
@@ -56,6 +61,8 @@ public class PropertyDescriptor implements IDescriptor {
     public List<PropertyDescriptor> getProperties() {
         return properties;
     }
+
+    public List<PropertyDescriptor> getAddedProperties(){ return addedProperties; }
 
     public Map<String, String> getAttributes() {
         return attributes;
@@ -71,6 +78,19 @@ public class PropertyDescriptor implements IDescriptor {
 
     public List<PropertyDescriptor> replaceProperties(List<PropertyDescriptor> newProperties){
         return this.properties = newProperties;
+    }
+
+    public List<PropertyDescriptor> addProperty(PropertyDescriptor newProperty){
+        this.addedProperties.add(newProperty);
+        return this.addedProperties;
+    }
+
+    public Map<String, String> addAttribute(String key, String value) {
+        if(attributes == null){
+            attributes = new HashMap<>();
+        }
+        attributes.put(key, value);
+        return attributes;
     }
 
     @Override

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -255,7 +255,7 @@ retainCharacteristicEnvVars = retainCharacteristicEnvVars
 processVariablesHandling = processVariablesHandling
 
 hudson.model.ParametersDefinitionProperty = parameters
-hudson.model.ParametersDefinitionProperty.type = OBJECT
+hudson.model.ParametersDefinitionProperty.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLObjectIgnoreParentStrategy
 
 # Copy Artifacts Build Step attributes
 hudson.plugins.copyartifact.CopyArtifact = copyArtifacts


### PR DESCRIPTION
## Ticket
[BUILD-3087](https://jira.tinyspeck.com/browse/BUILD-3087)

## Overview
The issue with the various parameter types is that we're getting errors when they're nested under properties.

I tested all the parameters used in this PR in its own `parameters` block under the job and it works! 

So how to get the parameters out of the properties object 🤔 The plugin and java support creating new child nodes pretty easily but going back to an earlier node and inserting a new child gets blocked because the iterator has a concurrent editing check.

The solution that ended up working was adding the child as an "added child" attribute to the grandparent and then going back and checking if any of the children added new nodes and then going over those. 

<img width="1125" alt="Screen Shot 2022-12-22 at 2 56 42 PM" src="https://user-images.githubusercontent.com/63604061/209239153-df860dfb-8487-42ac-89f7-a08f78680695.png">

## Testing

Test XML Used:
```
<project>
    <description>Apache httpd</description>
    <properties>
        <hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.StringParameterDefinition>
                    <name>branch</name>
                    <description>testing 456</description>
                    <defaultValue>testing 123</defaultValue>
                    <trim>false</trim>
                </hudson.model.StringParameterDefinition>
                <org.biouno.unochoice.ChoiceParameter plugin="uno-choice@2.6.4">
                    <name>himom 123</name>
                    <description>testing12321456</description>
                    <randomName>choice-parameter-18030166994973</randomName>
                    <visibleItemCount>1</visibleItemCount>
                    <projectName>test_hello_world</projectName>
                    <projectFullName>test_hello_world</projectFullName>
                    <choiceType>PT_RADIO</choiceType>
                    <filterable>false</filterable>
                    <filterLength>1</filterLength>
                </org.biouno.unochoice.ChoiceParameter>
                <org.biouno.unochoice.CascadeChoiceParameter plugin="uno-choice@2.6.4">
                    <name>testing 21231231</name>
                    <description>tesiting</description>
                    <randomName>choice-parameter-18030169458194</randomName>
                    <visibleItemCount>1</visibleItemCount>
                    <projectName>test_hello_world</projectName>
                    <projectFullName>test_hello_world</projectFullName>
                    <parameters class="linked-hash-map"/>
                    <referencedParameters/>
                    <choiceType>PT_CHECKBOX</choiceType>
                    <filterable>false</filterable>
                    <filterLength>1</filterLength>
                </org.biouno.unochoice.CascadeChoiceParameter>
                <org.biouno.unochoice.DynamicReferenceParameter plugin="uno-choice@2.6.4">
                    <name>testin566666g</name>
                    <description>testing 12o34i12</description>
                    <randomName>choice-parameter-18030171807015</randomName>
                    <visibleItemCount>1</visibleItemCount>
                    <projectName>test_hello_world</projectName>
                    <projectFullName>test_hello_world</projectFullName>
                    <parameters class="linked-hash-map"/>
                    <referencedParameters/>
                    <choiceType>ET_TEXT_BOX</choiceType>
                    <omitValueField>false</omitValueField>
                </org.biouno.unochoice.DynamicReferenceParameter>
                <hudson.model.BooleanParameterDefinition>
                    <name>boolea77777888n</name>
                    <description>true or false</description>
                    <defaultValue>false</defaultValue>
                </hudson.model.BooleanParameterDefinition>
                <hudson.model.TextParameterDefinition>
                    <name>testing999997654</name>
                    <description>multi line param</description>
                    <defaultValue>hi\n, mom\n</defaultValue>
                    <trim>false</trim>
                </hudson.model.TextParameterDefinition>
                <hudson.model.ChoiceParameterDefinition>
                    <name>choice paramet12313123er</name>
                    <description>testing choice parameter</description>
                    <choices class="java.util.Arrays$ArrayList">
                        <a class="string-array">
                            <string>choice parameter</string>
                        </a>
                    </choices>
                </hudson.model.ChoiceParameterDefinition>
                <hudson.model.FileParameterDefinition>
                    <name>/tmp/tes12`13243232</name>
                    <description>testing file param</description>
                </hudson.model.FileParameterDefinition>
                <com.cloudbees.plugins.credentials.CredentialsParameterDefinition plugin="credentials@1189.vf61b_a_5e2f62e">
                    <name>Testing credentials param42424242</name>
                    <description>testing credentials param</description>
                    <defaultValue>Jenkins-GHE-BG-SHAREDLIB</defaultValue>
                    <credentialType>com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey</credentialType>
                    <required>false</required>
                </com.cloudbees.plugins.credentials.CredentialsParameterDefinition>
            </parameterDefinitions>
            <hudson.plugins.promoted__builds.parameters.PromotedBuildParameterDefinition plugin="promoted-builds@892.vd6219fc0a_efb">
                <name>promoted build param</name>
                <description>testing</description>
                <projectName>offline-workers-job</projectName>
                <promotionProcessName/>
            </hudson.plugins.promoted__builds.parameters.PromotedBuildParameterDefinition>
            <hudson.model.PasswordParameterDefinition>
                <name>password</name>
                <description>testing</description>
                <defaultValue>{AQAAABAAAAAQcXCl9C+tXbVdfJ4EgCI8F2JU7XtSXaF0282hKC78EAA=}</defaultValue>
            </hudson.model.PasswordParameterDefinition>
            <org.jvnet.jenkins.plugins.nodelabelparameter.NodeParameterDefinition plugin="nodelabelparameter@1.11.0">
                <name>Node</name>
                <description>testing nodes</description>
                <allowedSlaves/>
                <defaultSlaves/>
                <triggerIfResult>success</triggerIfResult>
                <allowMultiNodeSelection>true</allowMultiNodeSelection>
                <triggerConcurrentBuilds>false</triggerConcurrentBuilds>
                <ignoreOfflineNodes>false</ignoreOfflineNodes>
                <nodeEligibility class="org.jvnet.jenkins.plugins.nodelabelparameter.node.IgnoreOfflineNodeEligibility"/>
            </org.jvnet.jenkins.plugins.nodelabelparameter.NodeParameterDefinition>
        </hudson.model.ParametersDefinitionProperty>
    </properties>
</project>
```

DSL Output:
```
job("test") {
	description("Apache httpd")
	parameters {
		stringParam("branch", "testing 456", "testing 123")
		activeChoiceParam("testing12321456") {
			choiceType("RADIO")
			filterable(false)
		}
		activeChoiceReactiveParam("tesiting") {
			parameters()
			choiceType("CHECKBOX")
			filterable(false)
		}
		activeChoiceReactiveReferenceParam("testing 12o34i12") {
			parameters()
			choiceType("TEXT_BOX")
			omitValueField(false)
		}
		booleanParam("boolea77777888n", false, "true or false")
		textParam("testing999997654", "hi\\n, mom\\n", "multi line param")
		choiceParam("choice paramet12313123er", ["choice parameter"], "testing choice parameter")
		credentialsParam("testing credentials param") {
			defaultValue("Jenkins-GHE-BG-SHAREDLIB")
			type("com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey")
			required(false)
		}
	}
}
```

I also tested that parameters that are alongside other properties still render properly:
```
properties {
		throttleJobProperty {
			maxConcurrentPerNode(0)
			maxConcurrentTotal(0)
			throttleEnabled(false)
			throttleOption("project")
			limitOneJobWithMatchingParams(false)
		}
	}
	disabled(false)
	concurrentBuild(false)
	parameters {
		stringParam("branch", "testing 456", "testing 123")
		activeChoiceParam("") {
			filterable(false)
			choiceType("RADIO")
```
