### PR TITLE
[BUILD-3100] throttleJob should not display if it is disabled

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLThrottleJobStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLThrottleJobStrategy.java
@@ -1,0 +1,38 @@
+package com.adq.jenkins.xmljobtodsl.dsl.strategies.custom;
+
+import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLObjectStrategy;
+import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
+
+/*
+throttleJobProperty is in the xml for all jobs whether or not it is being used.
+If any of the properties are left out of the dsl or don't contain a value, there are errors building the job
+This class will skip printing all the values if the throttle is disabled
+And gives us power in the future to handle things more flexibly.
+ */
+public class DSLThrottleJobStrategy extends DSLObjectStrategy {
+    private final String name;
+
+    public DSLThrottleJobStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name) {
+        this(tabs, propertyDescriptor, name, true);
+    }
+
+    public DSLThrottleJobStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name, boolean shouldInitChildren) {
+        super(tabs, propertyDescriptor, name, shouldInitChildren);
+        this.name = name;
+    }
+
+    @Override
+    public String toDSL() {
+        String childrenDSL = getChildrenDSL();
+
+        if (childrenDSL.isEmpty() || childrenDSL.contains("throttleEnabled(false)")) {
+            return "";
+        }
+
+        if (name != null) {
+            return replaceTabs(String.format(getSyntax("syntax.object_with_name"), name, childrenDSL), getTabs());
+        } else {
+            return replaceTabs(String.format(getSyntax("syntax.object"), childrenDSL), getTabs());
+        }
+    }
+}

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLThrottleJobStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLThrottleJobStrategy.java
@@ -3,22 +3,106 @@ package com.adq.jenkins.xmljobtodsl.dsl.strategies.custom;
 import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLObjectStrategy;
 import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 /*
 throttleJobProperty is in the xml for all jobs whether or not it is being used.
 If any of the properties are left out of the dsl or don't contain a value, there are errors building the job
-This class will skip printing all the values if the throttle is disabled
-And gives us power in the future to handle things more flexibly.
+This class will skip printing all the values if the throttle is disabled and will add missing properties if the feature is enabled
  */
 public class DSLThrottleJobStrategy extends DSLObjectStrategy {
     private final String name;
 
+    // This is the map of all the elements we want to guarantee will show up with throttleJobProperty and default values.
+    // matrixOptions being the exception which is taken care of later in the class.
+    private HashMap<String, String> expectedProperties = new HashMap<String, String>(){{
+        put("maxConcurrentPerNode", "0");
+        put("maxConcurrentTotal", "1");
+        put("categories", "");
+        put("throttleEnabled", "false");
+        put("throttleOption", "");
+        put("limitOneJobWithMatchingParams", "false");
+        put("paramsToUseForLimit", "");
+        put("matrixOptions", "");
+    }};
+
     public DSLThrottleJobStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name) {
         this(tabs, propertyDescriptor, name, true);
+        addMissingProperties(propertyDescriptor);
     }
 
     public DSLThrottleJobStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name, boolean shouldInitChildren) {
         super(tabs, propertyDescriptor, name, shouldInitChildren);
         this.name = name;
+        addMissingProperties(propertyDescriptor);
+    }
+
+    private void addMissingProperties(PropertyDescriptor propertyDescriptor){
+        // Make a copy of the properties that we can iterate over and remove elements as we go.
+        List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.addAll(propertyDescriptor.getProperties());
+
+        boolean featureEnabled = true;
+
+        for (HashMap.Entry<String, String> expectedProp : expectedProperties.entrySet()) {
+            boolean foundProperty = false;
+            int indexToRemove = 0;
+
+            if(!featureEnabled){
+                break;
+            }
+
+            for(PropertyDescriptor existingProp : properties){
+                if(existingProp.getName() == expectedProp.getKey()){
+                    foundProperty = true;
+                    indexToRemove = properties.indexOf(existingProp);
+                    break;
+                }
+                if(existingProp.getName().equals("throttleEnabled") && existingProp.getValue().equals("false")){
+                    featureEnabled = false;
+                    break;
+                }
+            }
+
+            if(foundProperty){
+                properties.remove(indexToRemove);
+            } else if (featureEnabled){
+                List<PropertyDescriptor> grandChildren = new ArrayList<>();
+                // matrixOptions is special as it's an object with subchildren that we'll create on the fly
+                if(expectedProp.getKey().equals("matrixOptions")){
+                    PropertyDescriptor throttleMatrixBuildsChild = new PropertyDescriptor(
+                        "throttleMatrixBuilds",
+                        null,
+                        "false"
+                    );
+
+                    PropertyDescriptor throttleMatrixConfigurationsChild = new PropertyDescriptor(
+                            "throttleMatrixConfigurations",
+                            null,
+                            "false"
+                    );
+
+                    grandChildren.add(throttleMatrixBuildsChild);
+                    grandChildren.add(throttleMatrixConfigurationsChild);
+                }
+
+                PropertyDescriptor newChild = new PropertyDescriptor(
+                        expectedProp.getKey(),
+                        propertyDescriptor.getParent(),
+                        expectedProp.getValue(),
+                        grandChildren,
+                        null
+                );
+
+                propertyDescriptor.getProperties().add(newChild);
+            }
+        }
+
+        if(featureEnabled){
+            initChildren(propertyDescriptor);
+        }
     }
 
     @Override

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -145,8 +145,8 @@ commitInfoChoice.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoN
 startNotification = startNotification
 
 hudson.plugins.throttleconcurrents.ThrottleJobProperty = throttleJobProperty
-hudson.plugins.throttleconcurrents.ThrottleJobProperty.type = OBJECT
-maxConcurrentPerNode =maxConcurrentPerNode
+hudson.plugins.throttleconcurrents.ThrottleJobProperty.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLThrottleJobStrategy
+maxConcurrentPerNode = maxConcurrentPerNode
 maxConcurrentTotal = maxConcurrentTotal
 categories = categories
 categories.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmptyMethodStrategy

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -155,7 +155,8 @@ throttleOption = throttleOption
 limitOneJobWithMatchingParams = limitOneJobWithMatchingParams
 paramsToUseForLimit = paramsToUseForLimit
 paramsToUseForLimit.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmptyMethodStrategy
-matrixOptions = OBJECT
+matrixOptions = matrixOptions
+matrixOptions.type = OBJECT
 throttleMatrixBuilds = throttleMatrixBuilds
 throttleMatrixConfigurations = throttleMatrixConfigurations
 


### PR DESCRIPTION
## Ticket

[BUILD-3100](https://jira.tinyspeck.com/browse/BUILD-3100)

## Overview
Copied over the object strategy but specifically tailored to jobThrottleProperty.

If there's throttle disabled in the child DSL, don't display the dsl

If throttle is **enabled** in the DSL, validate that all the children appear regardless of whether they're in the XML or not. This is to prevent errors while compiling DSL later.

## Testing

Test XML Used:
```
<project>
    <actions/>
    <description>Dev httpd</description>
    <keepDependencies>false</keepDependencies>
    <properties>
        <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@2.10">
            <maxConcurrentPerNode>0</maxConcurrentPerNode>
            <maxConcurrentTotal>0</maxConcurrentTotal>
            <categories class="java.util.concurrent.CopyOnWriteArrayList"/>
            <throttleEnabled>true</throttleEnabled>
            <throttleOption>project</throttleOption>
            <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
            <paramsToUseForLimit/>
        </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
        <hudson.plugins.copyartifact.CopyArtifactPermissionProperty plugin="copyartifact@1.46.4">
            <projectNameList>
                <string>agenda</string>
            </projectNameList>
        </hudson.plugins.copyartifact.CopyArtifactPermissionProperty>
    </properties>
```
 versus disabled:
```
<project>
    <actions/>
    <description>Dev httpd</description>
    <keepDependencies>false</keepDependencies>
    <properties>
        <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@2.10">
            <maxConcurrentPerNode>0</maxConcurrentPerNode>
            <maxConcurrentTotal>0</maxConcurrentTotal>
            <categories class="java.util.concurrent.CopyOnWriteArrayList"/>
            <throttleEnabled>false</throttleEnabled> <-- Value changed here
            <throttleOption>project</throttleOption>
            <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
            <paramsToUseForLimit/>
        </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
        <hudson.plugins.copyartifact.CopyArtifactPermissionProperty plugin="copyartifact@1.46.4">
            <projectNameList>
                <string>agenda</string>
            </projectNameList>
        </hudson.plugins.copyartifact.CopyArtifactPermissionProperty>
    </properties>
```

DSL Output:
```
job("test") {
	description("Dev httpd")
	keepDependencies(false)
	properties {
		throttleJobProperty {
			maxConcurrentPerNode(0)
			maxConcurrentTotal(0)
			throttleEnabled(true)
			throttleOption("project")
			limitOneJobWithMatchingParams(false)
		}
		copyArtifactPermission {
			projectNames("agenda")
		}
	}
```
vs
```
job("test") {
	description("Dev httpd")
	keepDependencies(false)
	properties {
		copyArtifactPermission {
			projectNames("agenda")
		}
	}
```
