### PR TITLE
BUILD-3115-add support for usernamePassword credentialsId and authenticationToken

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -6,6 +6,8 @@ project.type = INNER
 flow-definition = pipelineJob
 flow-definition.type = INNER
 
+authToken = authenticationToken
+
 com.tikal.jenkins.plugins.multijob.MultiJobProject = multiJob
 com.tikal.jenkins.plugins.multijob.MultiJobProject.type = INNER
 
@@ -75,7 +77,7 @@ room.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmp
 teamDomain = teamDomain
 teamDomain.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmptyMethodStrategy
 
-authToken = authToken
+jenkins.plugins.slack.SlackNotifier.authToken = authToken
 authToken.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmptyMethodStrategy
 
 authTokenCredentialId = teamDomain
@@ -474,6 +476,8 @@ bindings.type = OBJECT
 
 org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding = usernamePassword
 org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding.type = OBJECT
+
+org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding.credentialsId = credentialsId
 
 org.jenkinsci.plugins.credentialsbinding.impl.StringBinding = string
 


### PR DESCRIPTION
## Ticket

[JIRA-3115](https://jira.tinyspeck.com/browse/BUILD-3115)

## Overview
Noticed a couple issues that were causing job builds to fail. slackNotifier has an `authToken` method but there is also another method that should just be `authenticationToken`, and should render in the dsl as that. Error example:

`No signature of method: javaposse.jobdsl.dsl.jobs.FreeStyleJob.authToken() is applicable for argument types: (java.lang.String) values: [TOKEN]`
Also adding a path in translator.properties so that the credentialsId shows up correctly under usernamePassword within credentialsBinding

## Testing
Tested jobs using this formatting and they [successfully built](https://jenkins-tinyspeck-bedrock-dev.tinyspec) with the correct fields set in the UI on Jenkins TS.

Test XML Used:
The portions of xml containing the attributes being changed here: 
```
<project>      
    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
    <authToken>TOKEN</authToken>
 <buildWrappers>
        <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@523.vd859a_4b_122e6">
            <bindings>
                <org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
                    <credentialsId>JENKINS_SLACK_GITHUB_BOT_TOKEN</credentialsId>
                    <usernameVariable>SECRET_GHE_USERNAME</usernameVariable>
                    <passwordVariable>SECRET_GHE_PASSWORD</passwordVariable>
                </org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
            </bindings>
        </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
        <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.20"/>
        <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.24">
            <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
                <timeoutMinutes>60</timeoutMinutes>
            </strategy>
            <operationList>
                <hudson.plugins.build__timeout.operations.AbortOperation/>
            </operationList>
        </hudson.plugins.build__timeout.BuildTimeoutWrapper>
    </buildWrappers>
```
DSL Output:
Output for `authenticationToken`:
```
}
	label("qa")
	disabled(false)
	authenticationToken("TOKEN")
	concurrentBuild(true)
```

And for credentialsBinding -> usernamePassword:
```
wrappers {
		credentialsBinding {
			usernamePassword {
				credentialsId("JENKINS_SLACK_GITHUB_BOT_TOKEN")
				usernameVariable("SECRET_GHE_USERNAME")
				passwordVariable("SECRET_GHE_PASSWORD")
			}
		}
		timestamps()
		timeout {
			absolute(60)
		}
	}
```
