### PR TITLE
handle postBuildStep -> shell

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -166,6 +166,7 @@ template = template
 runAtStart = runAtStart
 runAtEnd = runAtEnd
 descriptionTemplate = descriptionTemplate
+descriptionTemplate.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmptyMethodStrategy
 
 com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty = naginatorOptOutProperty
 com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty.type = OBJECT
@@ -622,6 +623,11 @@ scriptOnlyIfFailure = onlyIfBuildFails
 
 org.jenkinsci.plugins.postbuildscript.model.PostBuildStep = postBuildStep
 org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.type = OBJECT
+
+#org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.buildSteps.hudson.tasks.Shell = shell
+#org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.buildSteps.hudson.tasks.Shell.type = OBJECT
+#
+#org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.buildSteps.hudson.tasks.Shell.command = command
 
 
 hudson.tasks.Mailer = mailer

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -624,10 +624,10 @@ scriptOnlyIfFailure = onlyIfBuildFails
 org.jenkinsci.plugins.postbuildscript.model.PostBuildStep = postBuildStep
 org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.type = OBJECT
 
-#org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.buildSteps.hudson.tasks.Shell = shell
-#org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.buildSteps.hudson.tasks.Shell.type = OBJECT
-#
-#org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.buildSteps.hudson.tasks.Shell.command = command
+org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.buildSteps.hudson.tasks.Shell = shell
+org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.buildSteps.hudson.tasks.Shell.type = OBJECT
+
+org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.buildSteps.hudson.tasks.Shell.command = command
 
 
 hudson.tasks.Mailer = mailer


### PR DESCRIPTION
## Ticket

[JIRA-3118](https://jira.tinyspeck.com/browse/BUILD-3118)

## Overview
Referencing [this](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.postBuildScript), when `shell` is under postBuildScript -> postBuildStep -> buildSteps, it should be an object with the method, `command` so that it renders in the UI correctly under Post Build Actions.  
Before this change, the dsl renders as: 
```
postBuildScript {
			buildSteps {
				postBuildStep {
					results("SUCCESS", "NOT_BUILT", "ABORTED", "FAILURE", "UNSTABLE")
					role("SLAVE")
					executeOn("BOTH")
					buildSteps {
						shell("""# Clean up folder for output
rm -rf tests/rspec-api-tests/tmp || true
mkdir tests/rspec-api-tests/tmp
```
`ERROR: (unknown source) No signature of method: javaposse.jobdsl.plugin.structs.DescribableListContext.shell() is applicable for argument types: (java.lang.String)`

Also, `descriptionTemplate` is not required if empty. Added a "type" for descriptionTemplate that uses our custom class so that it doesn't appear when empty, causing an error when building. 
```
buildNameSetter {
			template("#\${BUILD_NUMBER}")
			descriptionTemplate()
			runAtStart(true)
			runAtEnd(true)
		}
```

## Testing
After change it appears correctly under Post Build Actions.
<img width="497" alt="Screenshot 2022-12-28 at 2 35 35 PM" src="https://user-images.githubusercontent.com/112515811/209863519-21222f73-d9d0-4cbe-95fb-216a4613895e.png">


Test XML Used:
xml redacted for brevity
buildSteps -> shell:
```
<org.jenkinsci.plugins.postbuildscript.PostBuildScript plugin="postbuildscript@3.1.0-375.v3db_cd92485e1">
      <config>
        <scriptFiles/>
        <groovyScripts/>
        <buildSteps>
          <org.jenkinsci.plugins.postbuildscript.model.PostBuildStep>
            <results>
              <string>SUCCESS</string>
              <string>NOT_BUILT</string>
              <string>ABORTED</string>
              <string>FAILURE</string>
              <string>UNSTABLE</string>
            </results>
            <role>SLAVE</role>
            <executeOn>BOTH</executeOn>
            <buildSteps>
              <hudson.tasks.Shell>
                <command># Clean up folder for output
```
descriptionTemplate:
```
<org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@2.2.0">
      <template>#${BUILD_NUMBER}</template>
      <descriptionTemplate/>
      <runAtStart>true</runAtStart>
      <runAtEnd>true</runAtEnd>
    </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
```
DSL Output:
```
postBuildScript {
			buildSteps {
				postBuildStep {
					results("SUCCESS", "NOT_BUILT", "ABORTED", "FAILURE", "UNSTABLE")
					role("SLAVE")
					executeOn("BOTH")
					buildSteps {
						shell {
							command("""# Clean up folder for output")
						}
```
```
buildNameSetter {
			template("#\${BUILD_NUMBER}")
			runAtStart(true)
			runAtEnd(true)
		}
```