### PR TITLE
[BUILD-3101] Correct BuildTrigger translation

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -731,19 +731,19 @@ unstableThreshold = unstable
 
 failureThreshold = failure
 
-hudson.plugins.parameterizedtrigger.BuildTrigger = buildTrigger
-hudson.plugins.parameterizedtrigger.BuildTrigger.type = OBJECT
+hudson.plugins.parameterizedtrigger.BuildTrigger = it / 'publishers' / 'hudson.plugins.parameterizedtrigger.BuildTrigger'
+hudson.plugins.parameterizedtrigger.BuildTrigger.type = CONFIGURE
 
 hudson.plugins.parameterizedtrigger.BuildTrigger.configs = configs
 hudson.plugins.parameterizedtrigger.BuildTrigger.configs.type = OBJECT
 
-hudson.plugins.parameterizedtrigger.BuildTriggerConfig = buildTriggerConfig
+hudson.plugins.parameterizedtrigger.BuildTriggerConfig = 'hudson.plugins.parameterizedtrigger.BuildTriggerConfig'
 hudson.plugins.parameterizedtrigger.BuildTriggerConfig.type = OBJECT
 
 hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs = configs
 hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.type = OBJECT
 
-hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters = predefinedBuildParameters
+hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters = 'hudson.plugins.parameterizedtrigger.PredefinedBuildParameters'
 hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.type = OBJECT
 
 hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.parameterizedtrigger.BuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.properties = properties


### PR DESCRIPTION
## Ticket

[BUILD-3101](https://jira.tinyspeck.com/browse/BUILD-3101)

## Overview
The correctly translated DSL was getting this error
```
ERROR: Found multiple extensions which provide method buildTrigger with arguments [nw_bug_test$_run_closure1$_closure6$_closure15@20b9fbfc]: [hudson.tasks.BuildTrigger, hudson.plugins.parameterizedtrigger.BuildTrigger]
14:41:46 Finished: FAILURE 
```
Online it was suggested to use a configure block instead. I found this configure block to work manually:
```
// it / 'publishers' / 'hudson.plugins.parameterizedtrigger.BuildTrigger' {
		// 	configs {
		// 		'hudson.plugins.parameterizedtrigger.BuildTriggerConfig' {
		// 			configs {
		// 				'hudson.plugins.parameterizedtrigger.PredefinedBuildParameters' {
		// 					'properties'('ACT_BUILD_URL=$BUILD_URL')
		// 					'textParamValueOnNewLine'('false')							
		// 				}
		// 			}
		// 			'projects'('NotificationACT')
		// 			'condition'('FAILED_OR_BETTER')
		// 			'triggerWithNoParameters'('false')
		// 			'triggerFromChildProjects'('false')
		// 		}
		// 	}
		// }
```

Which is how I ended up changing the values in translator.properties so that the plugin would translate it to this exact configure block.

## Testing

Here's the seed job passing & the built job
<img width="1075" alt="Screenshot 2022-12-28 at 1 19 24 PM" src="https://user-images.githubusercontent.com/63604061/209873226-0264a8a8-8d09-400e-bd98-3a4b72f86c88.png">

<img width="1460" alt="Screenshot 2022-12-28 at 1 19 10 PM" src="https://user-images.githubusercontent.com/63604061/209873257-de2d2009-715f-4e62-9097-d173b66aca73.png">
