### PR TITLE
correct failing junitResultArchiver

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -60,6 +60,10 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("trim");
 		propertiesToBeSkipped.add("disableDeferredWipeout");
 		propertiesToBeSkipped.add("shallow");
+		propertiesToBeSkipped.add("skipPublishingChecks");
+		propertiesToBeSkipped.add("checksName");
+		propertiesToBeSkipped.add("skipMarkingBuildUnstable");
+		propertiesToBeSkipped.add("skipOldReports");
 
 		try {
 			initProperties();

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
@@ -34,6 +34,11 @@ public class DSLMethodStrategy extends AbstractDSLStrategy {
             if (isParentAMethod) {
                 return getStrategyForObject(propertyDescriptor).toDSL();
             }
+            if (propertyDescriptor.getName().equals("healthScaleFactor")) {
+                String[] str = propertyDescriptor.getValue().split("\\.");
+                return replaceTabs(String.format(getSyntax("syntax.method_call"),
+                        methodName, str[0]), getTabs());
+            }
 
             return replaceTabs(String.format(getSyntax("syntax.method_call"),
                     methodName, printValueAccordingOfItsType(propertyDescriptor.getValue())), getTabs());

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
@@ -34,13 +34,6 @@ public class DSLMethodStrategy extends AbstractDSLStrategy {
             if (isParentAMethod) {
                 return getStrategyForObject(propertyDescriptor).toDSL();
             }
-            if (propertyDescriptor.getName().equals("healthScaleFactor")) {
-                // value for healthScaleFactor should be an int in the dsl
-                double d = Double.parseDouble(propertyDescriptor.getValue());
-                int i = (int) d;
-                return replaceTabs(String.format(getSyntax("syntax.method_call"),
-                        methodName, i), getTabs());
-            }
 
             return replaceTabs(String.format(getSyntax("syntax.method_call"),
                     methodName, printValueAccordingOfItsType(propertyDescriptor.getValue())), getTabs());

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
@@ -35,9 +35,11 @@ public class DSLMethodStrategy extends AbstractDSLStrategy {
                 return getStrategyForObject(propertyDescriptor).toDSL();
             }
             if (propertyDescriptor.getName().equals("healthScaleFactor")) {
-                String[] str = propertyDescriptor.getValue().split("\\.");
+                // value for healthScaleFactor should be an int in the dsl
+                double d = Double.parseDouble(propertyDescriptor.getValue());
+                int i = (int) d;
                 return replaceTabs(String.format(getSyntax("syntax.method_call"),
-                        methodName, str[0]), getTabs());
+                        methodName, i), getTabs());
             }
 
             return replaceTabs(String.format(getSyntax("syntax.method_call"),

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -666,25 +666,16 @@ hudson.plugins.heavy__job.HeavyJobProperty = heavyJobProperty
 hudson.plugins.heavy__job.HeavyJobProperty.type = OBJECT
 weight = weight
 
-hudson.tasks.junit.JUnitResultArchiver = jUnitResultArchiver
-hudson.tasks.junit.JUnitResultArchiver.type = OBJECT
+hudson.tasks.junit.JUnitResultArchiver = archiveJunit
+hudson.tasks.junit.JUnitResultArchiver.type = CLOSURE
 
 testResults = testResults
 
 healthScaleFactor = healthScaleFactor
 
-keepLongStdio = keepLongStdio
+keepLongStdio = retainLongStdout
 
 allowEmptyResults = allowEmptyResults
-
-checksName = checksName
-checksName.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmptyMethodStrategy
-
-skipPublishingChecks = skipPublishingChecks
-
-skipMarkingBuildUnstable = skipMarkingBuildUnstable
-
-skipOldReports = skipOldReports
 
 com.cloudbees.jenkins.GitHubCommitNotifier = githubCommitNotifier
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -666,8 +666,8 @@ hudson.plugins.heavy__job.HeavyJobProperty = heavyJobProperty
 hudson.plugins.heavy__job.HeavyJobProperty.type = OBJECT
 weight = weight
 
-hudson.tasks.junit.JUnitResultArchiver = archiveJunit
-hudson.tasks.junit.JUnitResultArchiver.type = CLOSURE
+hudson.tasks.junit.JUnitResultArchiver = jUnitResultArchiver
+hudson.tasks.junit.JUnitResultArchiver.type = OBJECT
 
 testResults = testResults
 
@@ -678,6 +678,7 @@ keepLongStdio = keepLongStdio
 allowEmptyResults = allowEmptyResults
 
 checksName = checksName
+checksName.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmptyMethodStrategy
 
 skipPublishingChecks = skipPublishingChecks
 


### PR DESCRIPTION
## Ticket

[JIRA-3117](https://jira.tinyspeck.com/browse/BUILD-3117)

## Overview
DSL for jUnit is incorrect. There are two ways to create the job using dsl: [archiveJUnit](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.archiveJunit) and [jUnitResultArchiver](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.jUnitResultArchiver)

The dsl is currently rendering as:
```
	archiveJunit("tests/rspec-api-tests/tmp/rspec.xml") {
			keepLongStdio(false)
			healthScaleFactor(1.0)
			allowEmptyResults(true)
			skipPublishingChecks(false)
			checksName()
			skipMarkingBuildUnstable(false)
			skipOldReports(false)
		}
```
If we use the properties for archiveJUnit, `keepLongStdio` needs to be changed to `retainLongStdout` and the properties skipPublishingChecks, checksName, skipMarkingBuildUnstable, and skipOldReports need to be skipped since they aren't supported. 

When using the jUnitResultArchiver, we get an error around healthScaleFactor:

`No signature of method: javaposse.jobdsl.plugin.structs.DescribableContext.healthScaleFactor() is applicable for argument types: (java.math.BigDecimal) values: [1.0] `

When using archiveJUnit, `healthScaleFactor(1.0)` causes no issues. We'd just add the unsupported properties to propertiesToBeSkipped within the plugin. 

If we use the dynamic dsl for jUnitResultArchiver, `healthScaleFactor` needs to be an integer so that it correctly renders as 1.0. 

This PR adds the logic to render healthScaleFactor without the decimal as well as the other properties within jUnitResultArchiver. Also adds custom class to checksName so that it doesn't display if not used. 

## Testing

Successfully created job with jUnit test result report
<img width="600" alt="Screenshot 2022-12-29 at 11 58 17 AM" src="https://user-images.githubusercontent.com/112515811/209984968-6f5ca8a3-705f-4855-bbf8-13aef00cf9a9.png">

Test XML Used:
```
 <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1119.1121.vc43d0fc45561">
            <testResults>tests/rspec-api-tests/tmp/rspec.xml</testResults>
            <keepLongStdio>false</keepLongStdio>
            <healthScaleFactor>1.0</healthScaleFactor>
            <allowEmptyResults>true</allowEmptyResults>
            <skipPublishingChecks>false</skipPublishingChecks>
            <checksName/>
            <skipMarkingBuildUnstable>false</skipMarkingBuildUnstable>
            <skipOldReports>false</skipOldReports>
        </hudson.tasks.junit.JUnitResultArchiver>
```

DSL Output:
jUnitResultArchiver {
			testResults("tests/rspec-api-tests/tmp/rspec.xml")
			keepLongStdio(false)
			healthScaleFactor(1)
			allowEmptyResults(true)
			skipPublishingChecks(false)
			skipMarkingBuildUnstable(false)
			skipOldReports(false)
		}