### PR TITLE
[BUILD-3116] Results should be an array

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLArrayStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLArrayStrategy.java
@@ -3,13 +3,21 @@ package com.adq.jenkins.xmljobtodsl.dsl.strategies;
 import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
 
 public class DSLArrayStrategy extends DSLMethodStrategy implements IValueStrategy {
-
-	public DSLArrayStrategy(PropertyDescriptor descriptor) {
-		super(descriptor);
+	private String methodName;
+	public DSLArrayStrategy(int tabs, PropertyDescriptor propertyDescriptor, String methodName) {
+		super(tabs, propertyDescriptor, methodName);
+		this.methodName = methodName;
+		this.setTabs(tabs);
 	}
 
 	@Override
 	public String toDSL() {
-		return String.format(getSyntax("syntax.array"), getChildrenDSL());
+		String childrenDSL = getChildrenDSL();
+		if (!childrenDSL.isEmpty()) {
+			return replaceTabs(String.format(getSyntax("syntax.method_call"),
+					methodName, String.format("[%s]", childrenDSL)), getTabs());
+		} else {
+			return replaceTabs(String.format(getSyntax("syntax.array"), getChildrenDSL()), getTabs());
+		}
 	}
 }

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLArrayStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLArrayStrategy.java
@@ -4,16 +4,20 @@ import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
 
 public class DSLArrayStrategy extends DSLMethodStrategy implements IValueStrategy {
 	private String methodName;
+	private String parentType;
 	public DSLArrayStrategy(int tabs, PropertyDescriptor propertyDescriptor, String methodName) {
 		super(tabs, propertyDescriptor, methodName);
 		this.methodName = methodName;
 		this.setTabs(tabs);
+
+		parentType = getType(propertyDescriptor.getParent());
 	}
 
 	@Override
 	public String toDSL() {
 		String childrenDSL = getChildrenDSL();
-		if (!childrenDSL.isEmpty()) {
+		// Assume if the parent is an object that this is likely supposed to be a method as opposed to a parameter
+		if (parentType.equals("OBJECT")) {
 			return replaceTabs(String.format(getSyntax("syntax.method_call"),
 					methodName, String.format("[%s]", childrenDSL)), getTabs());
 		} else {

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLStrategyFactory.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLStrategyFactory.java
@@ -29,7 +29,7 @@ public class DSLStrategyFactory {
 			case TYPE_PROPERTY:
 				return new DSLPropertyStrategy(tabs, propertyDescriptor, property);
 			case TYPE_ARRAY:
-				return new DSLArrayStrategy(propertyDescriptor);
+				return new DSLArrayStrategy(tabs, propertyDescriptor, property);
 			case TYPE_METHOD:
 				return new DSLMethodStrategy(tabs, propertyDescriptor, property);
 			case TYPE_CLOSURE:

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLStringAsArrayStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLStringAsArrayStrategy.java
@@ -7,7 +7,7 @@ import com.adq.jenkins.xmljobtodsl.dsl.strategies.IValueStrategy;
 public class DSLStringAsArrayStrategy extends DSLArrayStrategy implements IValueStrategy {
 
 	public DSLStringAsArrayStrategy(int tabs, PropertyDescriptor descriptor, String name) {
-		super(descriptor);
+		super(tabs, descriptor, name);
 	}
 
 	@Override

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -623,6 +623,8 @@ scriptOnlyIfFailure = onlyIfBuildFails
 org.jenkinsci.plugins.postbuildscript.model.PostBuildStep = postBuildStep
 org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.type = OBJECT
 
+org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.results = results
+org.jenkinsci.plugins.postbuildscript.model.PostBuildStep.results.type = ARRAY
 
 hudson.tasks.Mailer = mailer
 


### PR DESCRIPTION
## Ticket

[BUILD-3116](https://jira.tinyspeck.com/browse/BUILD-3116)

## Overview
job with property: [ekm_delayed_messages_tests](https://jenkins.tinyspeck.com/job/ekm_delayed_messages_tests/)

results should be an array. https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#path/org.jenkinsci.plugins.postbuildscript.model.PostBuildStep$$List.postBuildStep-buildSteps-postBuildScript-buildSteps-postBuildStep

Error: 

```No signature of method: javaposse.jobdsl.plugin.structs.DescribableContext.results() is applicable for argument types: (java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String) values: [SUCCESS, NOT_BUILT, ABORTED, FAILURE, UNSTABLE]```

## Testing
Seed job finished successfully and job was configured correctly
<img width="1557" alt="Screenshot 2022-12-29 at 12 57 44 PM" src="https://user-images.githubusercontent.com/63604061/210010637-c566af61-3e08-4de4-a4e8-be850f5ad1e7.png">

<img width="473" alt="Screenshot 2022-12-29 at 12 58 25 PM" src="https://user-images.githubusercontent.com/63604061/210010550-7db8c201-2526-4562-8345-5fbbf5442ef3.png">

<img width="959" alt="Screenshot 2022-12-29 at 12 58 30 PM" src="https://user-images.githubusercontent.com/63604061/210010556-a659a460-8245-49ad-a165-bac0c4027b27.png">


Test XML Used (edited for brevity)
```
   <properties>
        <hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.ChoiceParameterDefinition>
                    <name>choice parameter</name>
                    <description>Testing choice parameter</description>
                    <choices class="java.util.Arrays$ArrayList">
                        <a class="string-array">
                            <string>1</string>
                            <string>2</string>
                            <string>3</string>
                        </a>
                    </choices>
                </hudson.model.ChoiceParameterDefinition>
            </parameterDefinitions>
        </hudson.model.ParametersDefinitionProperty>
        <hudson.plugins.heavy__job.HeavyJobProperty plugin="heavy-job@1.1">
            <weight>1</weight>
        </hudson.plugins.heavy__job.HeavyJobProperty>
    </properties>
    <publishers>
        <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.45">
            <configs>
                <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
                    <configs>
                        <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
                            <properties>ACT_BUILD_URL=$BUILD_URL</properties>
                            <textParamValueOnNewLine>false</textParamValueOnNewLine>
                        </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
                    </configs>
                    <projects>NotificationACT</projects>
                    <condition>FAILED_OR_BETTER</condition>
                    <triggerWithNoParameters>false</triggerWithNoParameters>
                    <triggerFromChildProjects>false</triggerFromChildProjects>
                </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
            </configs>
        </hudson.plugins.parameterizedtrigger.BuildTrigger>
        <org.jenkinsci.plugins.postbuildscript.PostBuildScript plugin="postbuildscript@3.1.0-375.v3db_cd92485e1">
            <config>
                <scriptFiles/>
                <groovyScripts/>
                <buildSteps>
                    <org.jenkinsci.plugins.postbuildscript.model.PostBuildStep>
                        <results>
                            <string>SUCCESS</string>
                            <string>NOT_BUILT</string>
                            <string>ABORTED</string>
                            <string>FAILURE</string>
                            <string>UNSTABLE</string>
                        </results>
                        <role>SLAVE</role>
                        <executeOn>BOTH</executeOn>
```

DSL Output:
```
		postBuildScript {
			buildSteps {
				postBuildStep {
					results(["SUCCESS", "NOT_BUILT", "ABORTED", "FAILURE", "UNSTABLE"])
					role("SLAVE")
					executeOn("BOTH")
					buildSteps {
						shell("# Clean up folder for output rm -rf tests/rspec-api-tests/tmp || true mkdir tests/rspec-api-tests/tmp # Get the name of the container from this run CONTAINER_NAME=\"\$(cat container_name.txt)\" # Copy the rspec output docker cp \"\${CONTAINER_NAME}\":/home/slack/tests/rspec-api-tests/output/rspec.xml \"\${WORKSPACE}\"/tests/rspec-api-tests/tmp/rspec.xml # Remove the container docker rm \"\${CONTAINER_NAME}\"")
					}
					stopOnFailure(false)
				}
			}
			markBuildUnstable(false)
		}
	}
	wrappers {
		timestamps()
		envInjectBuildWrapper {
			info {
				propertiesContent("TRIGGERED_BY=\${triggered_by}")
				secureGroovyScript {
					script()
					sandbox(true)
				}
				loadFilesFromMaster(false)
			}
		}
	}
	parameters {
		choiceParam("choice parameter", [1, 2, 3], "Testing choice parameter")
	}
```
