### PR TITLE
[BUILD-3123] Change cpsScm to cps and fix script type

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -812,10 +812,12 @@ lookupStrategy = lookupStrategy
 
 definition = definition
 definition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLHiddenTagStrategy
-definition.hidden_tag = cpsScm
+definition.hidden_tag = cps
 
-cpsScm = cpsScm
-cpsScm.type = OBJECT
+definition.script = script
+
+cps = cps
+cps.type = OBJECT
 
 scriptPath = scriptPath
 


### PR DESCRIPTION
## Ticket

[BUILD-3123](https://jira.tinyspeck.com/browse/BUILD-3123)

## Overview
The base `script` was set to be a parameter. That seems intentional enough that I wanted to leave it alone and make a more specific attribute for _this_ script that is in fact a method.

Also cpsSCM was a hidden tag which I easily enough changed the name.

## Testing

Test XML Used:
```
    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3536.vb_8a_6628079d5">
        <script>import jenkins.model.Jenkins import com.cloudbees.hudson.plugins.folder.* ... </script>
        <sandbox>true</sandbox>
    </definition>
```

DSL Output:
```
	definition {
		cps {
			script("import jenkins.model.Jenkins import com.cloudbees.hudson.plugins.folder.* ...")
			sandbox(true)
		}
	}
```

Validated the seed job passed ✅ 
Validated the job is configured correctly ✅ 
<img width="1357" alt="Screenshot 2022-12-30 at 3 26 54 PM" src="https://user-images.githubusercontent.com/63604061/210117789-5d36a649-dbec-4665-bcf3-a2733214058b.png">


