### PR TITLE
BUILD-3121 hudson.plugins.parameterizedtrigger.TriggerBuilder

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -786,9 +786,6 @@ hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.paramete
 hudson.plugins.parameterizedtrigger.BuildTriggerConfig.condition = condition
 hudson.plugins.parameterizedtrigger.BuildTriggerConfig.projects = projects
 
-#hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs = parameters
-#hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.type = OBJECT
-
 hudson.plugins.parameterizedtrigger.FileBuildParameterFactory.filePattern = filePattern
 hudson.plugins.parameterizedtrigger.FileBuildParameterFactory.noFilesFoundAction = noFilesFoundAction
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -493,6 +493,8 @@ org.jenkinsci.plugins.credentialsbinding.impl.StringBinding.variable.type = PARA
 org.jenkinsci.plugins.credentialsbinding.impl.StringBinding.credentialsId = credentialsId
 org.jenkinsci.plugins.credentialsbinding.impl.StringBinding.credentialsId.type = PARAMETER
 
+org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding.credentialsId = credentialsId
+
 usernameVariable = usernameVariable
 passwordVariable = passwordVariable
 
@@ -723,13 +725,35 @@ credentialIds = INNER
 credentialIds.string = credentialIds
 credentialIds.string.type = PARAMETER
 
-hudson.plugins.parameterizedtrigger.TriggerBuilder = downstreamParameterized
-hudson.plugins.parameterizedtrigger.TriggerBuilder.type = OBJECT
+#### configuring properties for hudson.plugins.parameterizedtrigger.TriggerBuilder #####
+hudson.plugins.parameterizedtrigger.TriggerBuilder = it / 'publishers' / 'hudson.plugins.parameterizedtrigger.TriggerBuilder'
+hudson.plugins.parameterizedtrigger.TriggerBuilder.type = CONFIGURE
 
+hudson.plugins.parameterizedtrigger.TriggerBuilder.configs = configs
+hudson.plugins.parameterizedtrigger.TriggerBuilder.configs.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig = 'hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig'
+hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.projects = projects
+hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.condition = condition
+hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.buildAllNodesWithLabel = buildAllNodesWithLabel
+
+hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs = configs
+hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configFactories = configFactories
+hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configFactories.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.FileBuildParameterFactory = 'hudson.plugins.parameterizedtrigger.FileBuildParameterFactory'
+hudson.plugins.parameterizedtrigger.FileBuildParameterFactory.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.TriggerBuilder.configs.hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters = 'hudson.plugins.parameterizedtrigger.PredefinedBuildParameters'
+hudson.plugins.parameterizedtrigger.TriggerBuilder.configs.hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.TriggerBuilder.configs.hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.properties = properties
+hudson.plugins.parameterizedtrigger.TriggerBuilder.configs.hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.textParamValueOnNewLine = textParamValueOnNewLine
 configs = INNER
-
-hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig = trigger
-hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.type = CLOSURE
 
 block = block
 block.type = OBJECT
@@ -762,8 +786,12 @@ hudson.plugins.parameterizedtrigger.BuildTrigger.configs.hudson.plugins.paramete
 hudson.plugins.parameterizedtrigger.BuildTriggerConfig.condition = condition
 hudson.plugins.parameterizedtrigger.BuildTriggerConfig.projects = projects
 
-hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs = parameters
-hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.type = OBJECT
+#hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs = parameters
+#hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.type = OBJECT
+
+hudson.plugins.parameterizedtrigger.FileBuildParameterFactory.filePattern = filePattern
+hudson.plugins.parameterizedtrigger.FileBuildParameterFactory.noFilesFoundAction = noFilesFoundAction
+
 
 hudson.plugins.parameterizedtrigger.BooleanParameters = INNER
 
@@ -791,7 +819,6 @@ bestResult.name.type = PARAMETER
 value = value
 value.type = PARAMETER
 
-hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters = predefinedProps
 hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.properties = properties
 hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig.configs.hudson.plugins.parameterizedtrigger.PredefinedBuildParameters.properties.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLStringAsArrayStrategy
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -789,7 +789,6 @@ hudson.plugins.parameterizedtrigger.BuildTriggerConfig.projects = projects
 hudson.plugins.parameterizedtrigger.FileBuildParameterFactory.filePattern = filePattern
 hudson.plugins.parameterizedtrigger.FileBuildParameterFactory.noFilesFoundAction = noFilesFoundAction
 
-
 hudson.plugins.parameterizedtrigger.BooleanParameters = INNER
 
 hudson.plugins.parameterizedtrigger.BooleanParameterConfig = booleanParam


### PR DESCRIPTION
## Ticket

[JIRA-3121](https://jira.tinyspeck.com/browse/BUILD-3121)

## Overview
Jobs were missing configuration and should match this syntax: https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/hudson.tasks.BuildStep$$List.buildTrigger
 This required adding a configure block similar to this [PR] (https://github.com/tinyspeck/xml-job-to-job-dsl-plugin/pull/55) and adding the specific paths  for the properties
## Testing
Confirmed the seedjob passes and the job was configured correctly
<img width="500" alt="Screenshot 2023-01-03 at 2 06 49 PM" src="https://user-images.githubusercontent.com/112515811/210424475-62a711e7-6d57-486e-b75a-81d6c3fcd048.png">

Also noticed while testing that credentialsId under sshUserPrivateKey wasn't rendering so a path was added for that.

Test XML Used:
```
<builders>
        <hudson.tasks.Shell>
            <command>bash autotransform/entrypoint.sh</command>
            <configuredLocalRules/>
        </hudson.tasks.Shell>
        <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@2.45">
            <configs>
                <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
                    <configs>
                        <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
                            <properties>REPO_URL=$REPO_URL BRANCH=$BRANCH</properties>
                            <textParamValueOnNewLine>false</textParamValueOnNewLine>
                        </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
                    </configs>
                    <configFactories>
                        <hudson.plugins.parameterizedtrigger.FileBuildParameterFactory>
                            <filePattern>autotransform/jenkins/job_*.txt</filePattern>
                            <noFilesFoundAction>SKIP</noFilesFoundAction>
                        </hudson.plugins.parameterizedtrigger.FileBuildParameterFactory>
                    </configFactories>
                    <projects>autotransform_executor</projects>
                    <condition>ALWAYS</condition>
                    <triggerWithNoParameters>false</triggerWithNoParameters>
                    <triggerFromChildProjects>false</triggerFromChildProjects>
                    <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
                </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
            </configs>
        </hudson.plugins.parameterizedtrigger.TriggerBuilder>
    </builders>
```
SSHUserPrivateKeyBinding Property
```
 <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@523.vd859a_4b_122e6">
            <bindings>
                <org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
                    <credentialsId>Jenkins-GHE</credentialsId>
                    <keyFileVariable>GHE_SSH_CREDENTIAL</keyFileVariable>
                </org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
            </bindings>
        </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
```

DSL Output:
```
it / 'publishers' / 'hudson.plugins.parameterizedtrigger.TriggerBuilder' {
			configs {
				'hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig' {
					configs {
						'hudson.plugins.parameterizedtrigger.PredefinedBuildParameters' {
							properties("REPO_URL=\$REPO_URL BRANCH=\$BRANCH")
							textParamValueOnNewLine(false)
						}
					}
					configFactories {
						'hudson.plugins.parameterizedtrigger.FileBuildParameterFactory' {
							filePattern("autotransform/jenkins/job_*.txt")
							noFilesFoundAction("SKIP")
						}
					}
					projects("autotransform_executor")
					condition("ALWAYS")
					triggerWithNoParameters(false)
					triggerFromChildProjects(false)
					buildAllNodesWithLabel(false)
				}
			}
		}
```
```
credentialsBinding {
			sshUserPrivateKey {
				credentialsId("Jenkins-GHE")
				keyFileVariable("GHE_SSH_CREDENTIAL")
			}
		}
```
