### PR TITLE
BUILD-3122 string and boolean params

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
@@ -4,6 +4,8 @@ import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLMethodStrategy;
 import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLStrategy;
 import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
 
+import java.util.List;
+
 public class DSLParamStrategy extends DSLMethodStrategy {
 
 	private final String methodName;
@@ -21,8 +23,14 @@ public class DSLParamStrategy extends DSLMethodStrategy {
 
 	public String getOrderedChildrenDSL() {
 		PropertyDescriptor propertyDescriptor = (PropertyDescriptor) getDescriptor();
-		if (propertyDescriptor.getName().equals("hudson.model.StringParameterDefinition")) {
-			String defaultValue = getChildrenByName("defaultValue").toDSL();
+		if (propertyDescriptor.getName().equals("hudson.model.StringParameterDefinition") || propertyDescriptor.getName().equals("hudson.model.BooleanParameterDefinition")) {
+			String defaultValue = "\"\"";
+			List <PropertyDescriptor> children = propertyDescriptor.getProperties();
+			for (PropertyDescriptor child : children ) {
+				if (child.getName().equals("defaultValue")) {
+					defaultValue = getChildrenByName("defaultValue").toDSL();
+				}
+			}
 			String name = getChildrenByName("name").toDSL();
 			String description = getChildrenByName("description").toDSL();
 			return name + ", " + defaultValue + ", " + description;

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -338,7 +338,7 @@ projectNameList = projectNames
 
 hudson.model.ParametersDefinitionProperty.parameterDefinitions = INNER
 
-hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.StringParameterDefinition = stringParam
+hudson.model.StringParameterDefinition = stringParam
 hudson.model.StringParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
 hudson.model.TextParameterDefinition = textParam


### PR DESCRIPTION
## Ticket

[JIRA-3122](https://jira.tinyspeck.com/browse/BUILD-3122)

## Overview
String parameters were being rendered in the wrong order which was causing the data to appear in the incorrect fields once a job was built. Should be: `stringParam(String parameterName, String defaultValue = null, String description = null)`. Additionally, looks like the `defaultValue` is missing from the xml entirely if it's not used; the custom class throws an error and the job fails to translate if a property is missing. `hudson.model.BooleanParameterDefinition` was also added to the if statement within the custom class.
```
Processing job: autotransform
Failed for job: autotransform
```

## Testing
- [x] Tested multiple jobs with different configurations of stringParam and booleanParam 
- [x] Confirmed jobs built successfully and were configured correctly 

Before change: description is incorrect
<img width="525" alt="Screenshot 2023-01-04 at 11 49 55 AM" src="https://user-images.githubusercontent.com/112515811/210606932-18f20ca2-4753-4def-8846-b5c6adc57f49.png">

Correct configuration:
<img width="525" alt="Screenshot 2023-01-04 at 11 54 52 AM" src="https://user-images.githubusercontent.com/112515811/210607982-12a66ac7-9c89-45cd-8038-e2b81886bce1.png">

Test XML Used:
stringParam without `defaultValue`
```
<hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.StringParameterDefinition>
                    <name>REPO_URL</name>
                    <description>The URL of the GHE repo that AutoTransform will operate against.</description>
                    <trim>false</trim>
                </hudson.model.StringParameterDefinition>
                <hudson.model.StringParameterDefinition>
                    <name>BRANCH</name>
                    <description>The branch from the repo that AutoTransform will operate against.</description>
                    <trim>false</trim>
                </hudson.model.StringParameterDefinition>
           </parameterDefinitions>
</hudson.model.ParametersDefinitionProperty>
```
stringParam with `defaultValue`
```
<hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.StringParameterDefinition>
                    <name>branch</name>
                    <description/>
                    <defaultValue>master</defaultValue>
                    <trim>false</trim>
                </hudson.model.StringParameterDefinition>
                <hudson.model.StringParameterDefinition>
                    <name>spec</name>
                    <description>Path to tests</description>
                    <defaultValue>./tests/cypress/e2e/platform/better-reminders/reminder-messaging.cy.js</defaultValue>
                    <trim>false</trim>
                </hudson.model.StringParameterDefinition>
          </parameterDefinitions>
</hudson.model.ParametersDefinitionProperty>
```
booleanParam
```
<hudson.model.ParametersDefinitionProperty>
          <parameterDefinitions>
               <hudson.model.BooleanParameterDefinition>
                    <name>BOOTSTRAP</name>
                    <description>Whether to build bootstrap images, rather than pull them. (this is currently ignored)</description>
                    <defaultValue>false</defaultValue>
                </hudson.model.BooleanParameterDefinition>
         </parameterDefinitions>
</hudson.model.ParametersDefinitionProperty>
```

DSL Output:
```
parameters {
		stringParam("REPO_URL", "", "The URL of the GHE repo that AutoTransform will operate against.")
		stringParam("BRANCH", "", "The branch from the repo that AutoTransform will operate against.")
	}

```
```
parameters {
		stringParam("branch", "master", "")
		stringParam("spec", "./tests/cypress/e2e/platform/better-reminders/reminder-messaging.cy.js", "Path to tests")
		stringParam("iterations", 1, "Specify how many times you want to run the test(s).")
		stringParam("browser", "chrome", "Chrome or electron")
	}
```
```
parameters {
		booleanParam("BOOTSTRAP", false, "Whether to build bootstrap images, rather than pull them. (this is currently ignored)")
	}
```
