### PR TITLE
correct singleConditionalBuilder property and add path to buildStep w…

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -793,8 +793,11 @@ hudson.plugins.parameterizedtrigger.BooleanParameters = INNER
 
 hudson.plugins.parameterizedtrigger.BooleanParameterConfig = booleanParam
 
-org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder = singleConditionalBuilder
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder = conditionalSteps
 org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.type = OBJECT
+
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.buildStep = steps
+org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.buildStep.type = OBJECT
 
 org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition = condition
 org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition.type = OBJECT


### PR DESCRIPTION
## Ticket

[JIRA-3129](https://jira.tinyspeck.com/browse/BUILD-3129)

## Overview
`<org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder plugin="conditional-buildstep@1.4.2">` is being converted as `singleConditionalBuilder` and is failing when building jobs: 

`ERROR: (unknown source) the following options are required and must be specified: buildStep, runner
16:34:47 Finished: FAILURE`

Using `conditionalSteps` and this [syntax](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.step.StepContext.conditionalSteps), the jobs build successfully.
Also added a path for the buildsteps within conditionalSteps so that the shell command renders correctly

## Testing
- [X] Confirmed job builds successfully
- [X] Confirmed job is configured correctly
<img width="1150" alt="Screenshot 2023-01-04 at 4 56 38 PM" src="https://user-images.githubusercontent.com/112515811/210657546-697543e3-cb21-4d21-b3b3-91d415da6cf7.png">


Test XML Used:
```
<org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder plugin="conditional-buildstep@1.4.2">
            <condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition" plugin="run-condition@1.5">
                <worstResult>
                    <name>SUCCESS</name>
                    <ordinal>0</ordinal>
                    <color>BLUE</color>
                    <completeBuild>true</completeBuild>
                </worstResult>
                <bestResult>
                    <name>SUCCESS</name>
                    <ordinal>0</ordinal>
                    <color>BLUE</color>
                    <completeBuild>true</completeBuild>
                </bestResult>
            </condition>
            <buildStep class="hudson.tasks.Shell">
                <command>Testing</command>
                <configuredLocalRules/>
            </buildStep>
            <runner class="org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail" plugin="run-condition@1.5"/>
        </org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder>
```

DSL Output:
```
singleConditionalBuilder {
			condition {
				statusCondition {
					worstResult("SUCCESS")
					bestResult("SUCCESS")
				}
			}
			steps {
				shell("Testing")
			}
		}
```
