### PR TITLE
credentialsBinding order, abortBuild, paramsToUseForLimit

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -42,7 +42,6 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("submoduleCfg");
 		propertiesToBeSkipped.add("doGenerateSubmoduleConfigurations");
 		propertiesToBeSkipped.add("canRoam");
-		propertiesToBeSkipped.add("operationList");
 		propertiesToBeSkipped.add("caseSensitive");
 		propertiesToBeSkipped.add("followSymlinks");
 		propertiesToBeSkipped.add("completeBuild");

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
@@ -25,17 +25,14 @@ public class DSLParamStrategy extends DSLMethodStrategy {
 		PropertyDescriptor propertyDescriptor = (PropertyDescriptor) getDescriptor();
 		if (propertyDescriptor.getName().equals("hudson.model.StringParameterDefinition") || propertyDescriptor.getName().equals("hudson.model.BooleanParameterDefinition")) {
 			String defaultValue = "\"\"";
-			String description = "\"\"";
 			List <PropertyDescriptor> children = propertyDescriptor.getProperties();
 			for (PropertyDescriptor child : children ) {
 				if (child.getName().equals("defaultValue")) {
 					defaultValue = getChildrenByName("defaultValue").toDSL();
 				}
-				if (child.getName().equals("description")) {
-					description = getChildrenByName("description").toDSL();
-				}
 			}
 			String name = getChildrenByName("name").toDSL();
+			String description = getChildrenByName("description").toDSL();
 			return name + ", " + defaultValue + ", " + description;
 
 		} else {

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
@@ -25,14 +25,17 @@ public class DSLParamStrategy extends DSLMethodStrategy {
 		PropertyDescriptor propertyDescriptor = (PropertyDescriptor) getDescriptor();
 		if (propertyDescriptor.getName().equals("hudson.model.StringParameterDefinition") || propertyDescriptor.getName().equals("hudson.model.BooleanParameterDefinition")) {
 			String defaultValue = "\"\"";
+			String description = "\"\"";
 			List <PropertyDescriptor> children = propertyDescriptor.getProperties();
 			for (PropertyDescriptor child : children ) {
 				if (child.getName().equals("defaultValue")) {
 					defaultValue = getChildrenByName("defaultValue").toDSL();
 				}
+				if (child.getName().equals("description")) {
+					description = getChildrenByName("description").toDSL();
+				}
 			}
 			String name = getChildrenByName("name").toDSL();
-			String description = getChildrenByName("description").toDSL();
 			return name + ", " + defaultValue + ", " + description;
 
 		} else {

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -156,7 +156,7 @@ throttleEnabled = throttleEnabled
 throttleOption = throttleOption
 limitOneJobWithMatchingParams = limitOneJobWithMatchingParams
 paramsToUseForLimit = paramsToUseForLimit
-paramsToUseForLimit.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmptyMethodStrategy
+paramsToUseForLimit.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLMandatoryStringStrategy
 matrixOptions = matrixOptions
 matrixOptions.type = OBJECT
 throttleMatrixBuilds = throttleMatrixBuilds
@@ -464,6 +464,9 @@ depth = depth
 
 honorRefspec = honorRefspec
 
+operationList = INNER
+operationList.hudson.plugins.build__timeout.operations.AbortOperation = abortBuild
+
 triggerWithNoParameters = triggerWithNoParameters
 triggerFromChildProjects = triggerFromChildProjects
 
@@ -485,6 +488,7 @@ org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding.type 
 org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding.credentialsId = credentialsId
 
 org.jenkinsci.plugins.credentialsbinding.impl.StringBinding = string
+org.jenkinsci.plugins.credentialsbinding.impl.StringBinding.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
 org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordBinding = usernamePassword
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -185,6 +185,7 @@ urlInfo = urlInfo
 urlInfo.type = OBJECT
 urlType = urlType
 urlOrId = urlOrId
+urlOrId.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLMandatoryStringStrategy
 
 
 protocol = protocol


### PR DESCRIPTION
## Ticket

No Jira

## Overview
Correcting issues causing failing jobs due to:

- credentialsBinding parameters being in the wrong order.
- throttleJobProperty->paramsToUseForLimit must be present
- add support for abortBuild method

## Testing
Confirmed the jobs are created and configured correctly with for each of the above issues. 
<img width="847" alt="Screenshot 2023-01-06 at 5 20 14 PM" src="https://user-images.githubusercontent.com/112515811/211109576-ea7c33ac-afd3-45ac-9364-c3ddfc4df68d.png">
<img width="849" alt="Screenshot 2023-01-06 at 5 21 30 PM" src="https://user-images.githubusercontent.com/112515811/211109751-b245c5e3-dbd8-46b7-bce0-aa0204011f4f.png">

Test XML Used:

credentialsBinding:
```
<buildWrappers>
   <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@523.vd859a_4b_122e6">
      <bindings>
           <org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
               <credentialsId>SLACK_SECRET_ALERTS_BOT_TOKEN</credentialsId>
               <variable>SLACK_SECRET_ALERTS_BOT_TOKEN</variable>
          </org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
          <org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
              <credentialsId>SNYK_API_KEY</credentialsId>
              <variable>SNYk_API_KEY</variable>
          </org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
    </bindings>
  </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
</buildWrappers>
```
Abort build:
```
<operationList>
    <hudson.plugins.build__timeout.operations.AbortOperation/>
</operationList>
```

DSL Output:
```
wrappers {
		credentialsBinding {
			string("SLACK_SECRET_ALERTS_BOT_TOKEN", "SLACK_SECRET_ALERTS_BOT_TOKEN")
			string("SNYk_API_KEY", "SNYK_API_KEY")
		}
	}
```
abortBuild:
```
timestamps()
		timeout {
			absolute(60)
			abortBuild()
		}
```

