### PR TITLE
add dynamic dsl for parameterDefinitions

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -55,7 +55,6 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("color");
 		propertiesToBeSkipped.add("activeProcessNames");
 		propertiesToBeSkipped.add("isVisible");
-//		propertiesToBeSkipped.add("trim");
 		propertiesToBeSkipped.add("disableDeferredWipeout");
 		propertiesToBeSkipped.add("shallow");
 		propertiesToBeSkipped.add("skipPublishingChecks");
@@ -245,7 +244,6 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
 			return value;
 		}
-
 		if (value.matches("-?[0-9.]+") && countChar('.', value) < 2) {
 			return value;
 		}

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/AbstractDSLStrategy.java
@@ -55,7 +55,7 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		propertiesToBeSkipped.add("color");
 		propertiesToBeSkipped.add("activeProcessNames");
 		propertiesToBeSkipped.add("isVisible");
-		propertiesToBeSkipped.add("trim");
+//		propertiesToBeSkipped.add("trim");
 		propertiesToBeSkipped.add("disableDeferredWipeout");
 		propertiesToBeSkipped.add("shallow");
 		propertiesToBeSkipped.add("skipPublishingChecks");
@@ -245,6 +245,7 @@ public abstract class AbstractDSLStrategy implements DSLStrategy {
 		if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
 			return value;
 		}
+
 		if (value.matches("-?[0-9.]+") && countChar('.', value) < 2) {
 			return value;
 		}

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
@@ -5,6 +5,7 @@ import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
 import java.util.ArrayList;
 import java.util.List;
 
+
 public class DSLMethodStrategy extends AbstractDSLStrategy {
 
     private final String methodName;

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/DSLMethodStrategy.java
@@ -5,7 +5,6 @@ import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
 import java.util.ArrayList;
 import java.util.List;
 
-
 public class DSLMethodStrategy extends AbstractDSLStrategy {
 
     private final String methodName;

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLChoiceParamStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLChoiceParamStrategy.java
@@ -27,9 +27,8 @@ public class DSLChoiceParamStrategy extends DSLMethodStrategy {
 
 		List<PropertyDescriptor> children = propertyDescriptor.getProperties();
 		for (PropertyDescriptor child : children ) {
-			if (child.getName().equals("defaultValue")) {
+			if (child.getName().equals("description")) {
 				description = getChildrenByName("description").toDSL();
-
 			}
 		}
 		String choices = getChildrenByName("choices").toDSL();

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLChoiceParamStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLChoiceParamStrategy.java
@@ -4,6 +4,8 @@ import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
 import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLMethodStrategy;
 import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLStrategy;
 
+import java.util.List;
+
 public class DSLChoiceParamStrategy extends DSLMethodStrategy {
 
 	private final String methodName;
@@ -20,9 +22,18 @@ public class DSLChoiceParamStrategy extends DSLMethodStrategy {
 	}
 
 	public String getOrderedChildrenDSL() {
+		PropertyDescriptor propertyDescriptor = (PropertyDescriptor) getDescriptor();
+		String description = "\"\"";
+
+		List<PropertyDescriptor> children = propertyDescriptor.getProperties();
+		for (PropertyDescriptor child : children ) {
+			if (child.getName().equals("defaultValue")) {
+				description = getChildrenByName("description").toDSL();
+
+			}
+		}
 		String choices = getChildrenByName("choices").toDSL();
 		String name = getChildrenByName("name").toDSL();
-		String description = getChildrenByName("description").toDSL();
-		return name + ", " + choices + ", " + description;
+		return name + ", " + choices  + ", " + description;
 	}
 }

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
@@ -24,16 +24,18 @@ public class DSLParamStrategy extends DSLMethodStrategy {
 	public String getOrderedChildrenDSL() {
 		PropertyDescriptor propertyDescriptor = (PropertyDescriptor) getDescriptor();
 		if (propertyDescriptor.getName().equals("hudson.model.StringParameterDefinition") || propertyDescriptor.getName().equals("hudson.model.BooleanParameterDefinition")) {
-			String defaultValue = "\"\"";
+			String defaultValue = "\"\"", description = "\"\"";
 			List <PropertyDescriptor> children = propertyDescriptor.getProperties();
 			for (PropertyDescriptor child : children ) {
 				if (child.getName().equals("defaultValue")) {
 					defaultValue = getChildrenByName("defaultValue").toDSL();
 
 				}
+				if (child.getName().equals("description")) {
+					description = getChildrenByName("description").toDSL();
+				}
 			}
 			String name = getChildrenByName("name").toDSL();
-			String description = getChildrenByName("description").toDSL();
 			return name + ", " + defaultValue + ", " + description;
 
 		} else {

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLParamStrategy.java
@@ -29,6 +29,7 @@ public class DSLParamStrategy extends DSLMethodStrategy {
 			for (PropertyDescriptor child : children ) {
 				if (child.getName().equals("defaultValue")) {
 					defaultValue = getChildrenByName("defaultValue").toDSL();
+
 				}
 			}
 			String name = getChildrenByName("name").toDSL();

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -409,24 +409,6 @@ hudson.plugins.copyartifact.CopyArtifactPermissionProperty.type = OBJECT
 
 projectNameList = projectNames
 
-###### commenting out for testing dynamic ##########
-#hudson.model.ParametersDefinitionProperty.parameterDefinitions = INNER
-
-#hudson.model.StringParameterDefinition = stringParam
-#hudson.model.StringParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
-
-#hudson.model.TextParameterDefinition = textParam
-#hudson.model.TextParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
-
-#name = PARAM_NAME
-#name.type = PARAMETER
-#
-#defaultValue = PARAM_DEFAULT_VALUE
-#defaultValue.type = PARAMETER
-#
-#description = PARAM_DESCRIPTION
-#description.type = PARAMETER
-
 pre.type = PARAMETER
 
 com.cloudbees.plugins.credentials.CredentialsParameterDefinition = credentialsParam
@@ -442,21 +424,6 @@ com.cloudbees.plugins.credentials.CredentialsParameterDefinition.required = requ
 
 credentialType = type
 credentialType.type = PARAMETER
-
-#hudson.model.ChoiceParameterDefinition = choiceParam
-#hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
-
-#choices = INNER
-#choices.type = INNER
-#
-#a = a
-#a.type = ARRAY
-#
-#string = string
-#string.type = PARAMETER
-
-#hudson.model.BooleanParameterDefinition = booleanParam
-#hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
 scm = scm
 scm.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLHiddenTagStrategy

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -300,23 +300,35 @@ hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.Bool
 hudson.plugins.copyartifact.CopyArtifact = copyArtifacts
 hudson.plugins.copyartifact.CopyArtifact.type = CLOSURE
 
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions = parameters
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.type = OBJECT
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions = parameters
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.type = OBJECT
 
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition = choiceParam
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
-#
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices = INNER
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.type = INNER
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition = choiceParam
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
 
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a = a
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.type = ARRAY
-#
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string = string
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string.type = PARAMETER
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.name = PARAM_NAME
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.name.type = PARAMETER
 
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition = booleanParam
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.description = PARAM_DESCRIPTION
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.description.type = PARAMETER
+
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices = INNER
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.type = INNER
+
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a = a
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.type = ARRAY
+
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string = string
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string.type = PARAMETER
+
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition = booleanParam
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.name = PARAM_NAME
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.name.type = PARAMETER
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.description = PARAM_DESCRIPTION
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.description.type = PARAMETER
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.defaultValue = PARAM_DEFAULT_VALUE
+hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.defaultValue.type = PARAMETER
 
 parameters = parameters
 filter = includePatterns

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -303,32 +303,32 @@ hudson.plugins.copyartifact.CopyArtifact.type = CLOSURE
 hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions = parameters
 hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.type = OBJECT
 
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition = choiceParam
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition = choiceParam
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
 
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.name = PARAM_NAME
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.name.type = PARAMETER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.name = PARAM_NAME
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.name.type = PARAMETER
 
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.description = PARAM_DESCRIPTION
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.description.type = PARAMETER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.description = PARAM_DESCRIPTION
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.description.type = PARAMETER
 
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices = INNER
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.type = INNER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices = INNER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.type = INNER
 
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a = a
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.type = ARRAY
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a = a
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.type = ARRAY
 
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string = string
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string.type = PARAMETER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string = string
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string.type = PARAMETER
 
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition = booleanParam
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.name = PARAM_NAME
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.name.type = PARAMETER
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.description = PARAM_DESCRIPTION
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.description.type = PARAMETER
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.defaultValue = PARAM_DEFAULT_VALUE
-hudson.plugins.promoted__builds.PromotionProcess.conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.defaultValue.type = PARAMETER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition = booleanParam
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.name = PARAM_NAME
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.name.type = PARAMETER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.description = PARAM_DESCRIPTION
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.description.type = PARAMETER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.defaultValue = PARAM_DEFAULT_VALUE
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.defaultValue.type = PARAMETER
 
 parameters = parameters
 filter = includePatterns

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -263,12 +263,60 @@ variables = variables
 retainCharacteristicEnvVars = retainCharacteristicEnvVars
 processVariablesHandling = processVariablesHandling
 
+
 hudson.model.ParametersDefinitionProperty = parameters
 hudson.model.ParametersDefinitionProperty.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLObjectIgnoreParentStrategy
+
+hudson.model.ParametersDefinitionProperty.parameterDefinitions = parameters
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.type = OBJECT
+
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.StringParameterDefinition = stringParam
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.StringParameterDefinition.type = OBJECT
+
+hudson.model.StringParameterDefinition.name = name
+hudson.model.StringParameterDefinition.description = description
+hudson.model.StringParameterDefinition.description.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLMandatoryStringStrategy
+hudson.model.StringParameterDefinition.defaultValue = defaultValue
+hudson.model.StringParameterDefinition.trim = trim
+
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition = choiceParam
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition.type = OBJECT
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition.name = name
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition.description = description
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices = choices
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.type = ARRAY
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a = INNER
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.type = INNER
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string = string
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string.type = PARAMETER
+
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.BooleanParameterDefinition = booleanParam
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.BooleanParameterDefinition.type = OBJECT
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.BooleanParameterDefinition.name = name
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.BooleanParameterDefinition.description = description
+hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.BooleanParameterDefinition.defaultValue = defaultValue
 
 # Copy Artifacts Build Step attributes
 hudson.plugins.copyartifact.CopyArtifact = copyArtifacts
 hudson.plugins.copyartifact.CopyArtifact.type = CLOSURE
+
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions = parameters
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.type = OBJECT
+
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition = choiceParam
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
+#
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices = INNER
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.type = INNER
+
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a = a
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.type = ARRAY
+#
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string = string
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.ChoiceParameterDefinition.choices.a.string.type = PARAMETER
+
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition = booleanParam
+hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
 parameters = parameters
 filter = includePatterns
@@ -340,22 +388,23 @@ hudson.plugins.copyartifact.CopyArtifactPermissionProperty.type = OBJECT
 
 projectNameList = projectNames
 
-hudson.model.ParametersDefinitionProperty.parameterDefinitions = INNER
+###### commenting out for testing dynamic ##########
+#hudson.model.ParametersDefinitionProperty.parameterDefinitions = INNER
 
-hudson.model.StringParameterDefinition = stringParam
-hudson.model.StringParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
+#hudson.model.StringParameterDefinition = stringParam
+#hudson.model.StringParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
-hudson.model.TextParameterDefinition = textParam
-hudson.model.TextParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
+#hudson.model.TextParameterDefinition = textParam
+#hudson.model.TextParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
-name = PARAM_NAME
-name.type = PARAMETER
-
-defaultValue = PARAM_DEFAULT_VALUE
-defaultValue.type = PARAMETER
-
-description = PARAM_DESCRIPTION
-description.type = PARAMETER
+#name = PARAM_NAME
+#name.type = PARAMETER
+#
+#defaultValue = PARAM_DEFAULT_VALUE
+#defaultValue.type = PARAMETER
+#
+#description = PARAM_DESCRIPTION
+#description.type = PARAMETER
 
 pre.type = PARAMETER
 
@@ -373,20 +422,20 @@ com.cloudbees.plugins.credentials.CredentialsParameterDefinition.required = requ
 credentialType = type
 credentialType.type = PARAMETER
 
-hudson.model.ChoiceParameterDefinition = choiceParam
-hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
+#hudson.model.ChoiceParameterDefinition = choiceParam
+#hudson.model.ChoiceParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceParamStrategy
 
-choices = INNER
-choices.type = INNER
+#choices = INNER
+#choices.type = INNER
+#
+#a = a
+#a.type = ARRAY
+#
+#string = string
+#string.type = PARAMETER
 
-a = a
-a.type = ARRAY
-
-string = string
-string.type = PARAMETER
-
-hudson.model.BooleanParameterDefinition = booleanParam
-hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
+#hudson.model.BooleanParameterDefinition = booleanParam
+#hudson.model.BooleanParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
 
 scm = scm
 scm.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLHiddenTagStrategy
@@ -961,9 +1010,6 @@ hudson.plugins.promoted__builds.PromotionProcess.type = OBJECT
 
 hudson.plugins.promoted__builds.conditions.ManualCondition = manual
 hudson.plugins.promoted__builds.conditions.ManualCondition.type = CLOSURE
-
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions = parameters
-hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.type = OBJECT
 
 user.type = PARAMETER
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -263,7 +263,6 @@ variables = variables
 retainCharacteristicEnvVars = retainCharacteristicEnvVars
 processVariablesHandling = processVariablesHandling
 
-
 hudson.model.ParametersDefinitionProperty = parameters
 hudson.model.ParametersDefinitionProperty.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLObjectIgnoreParentStrategy
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -330,6 +330,15 @@ conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterD
 conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.defaultValue = PARAM_DEFAULT_VALUE
 conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.BooleanParameterDefinition.defaultValue.type = PARAMETER
 
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.StringParameterDefinition = stringParam
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.StringParameterDefinition.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLParamStrategy
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.StringParameterDefinition.name = PARAM_NAME
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.StringParameterDefinition.name.type = PARAMETER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.StringParameterDefinition.description = PARAM_DESCRIPTION
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.StringParameterDefinition.description.type = PARAMETER
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.StringParameterDefinition.defaultValue = PARAM_DEFAULT_VALUE
+conditions.hudson.plugins.promoted__builds.conditions.ManualCondition.parameterDefinitions.hudson.model.StringParameterDefinition.defaultValue.type = PARAMETER
+
 parameters = parameters
 filter = includePatterns
 target = targetDirectory


### PR DESCRIPTION
## Ticket

[JIRA-3152](https://jira.tinyspeck.com/browse/BUILD-3152)

## Overview
Parameters can be defined using:
```
parameters {
        stringParam('myParameterName', 'my default stringParam value', 'my description')
    }
```
or by using the dynamic dsl:
```
stringParam {
     name(String value)
     defaultValue(String value)
     description(String value)
     trim(boolean value)
}
```

`trim` is being used often, therefore support for the dynamic dsl was added. This syntax causes errors when used within a promotion block, so support for the alternative was added when used within that context. 

## Testing
Confirmed seedjob builds and is configured correctly for the root level job and each promotion.

<img width="500" alt="Screenshot 2023-01-11 at 11 30 28 AM" src="https://user-images.githubusercontent.com/112515811/211862074-753ed830-65e1-4b51-8d70-316599e58142.png">

<img width="500" alt="Screenshot 2023-01-11 at 11 29 34 AM" src="https://user-images.githubusercontent.com/112515811/211862316-77f07ef7-620d-4ddb-88af-00cf272048bc.png">

There seems to be a bug when using the choiceParam within a promotion, where the choices are not rendering correctly. Came across this Jenkins [issue ](https://issues.jenkins.io/browse/JENKINS-38913) which indicates this may still need to be fixed.

<img width="836" alt="Screenshot 2023-01-11 at 11 17 31 AM" src="https://user-images.githubusercontent.com/112515811/211862572-dce1002d-6ad5-41c1-a288-e536b2246ac8.png">


Test XML Used:
Within root config.xml
```
<hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.ChoiceParameterDefinition>
                    <name>ROLL_ENV</name>
                    <choices class="java.util.Arrays$ArrayList">
                        <a class="string-array">
                            <string>dev</string>
                            <string>test</string>
                            <string>prod</string>
                        </a>
                    </choices>
                </hudson.model.ChoiceParameterDefinition>
                <hudson.model.BooleanParameterDefinition>
                    <name>DRY_RUN</name>
                    <defaultValue>true</defaultValue>
                </hudson.model.BooleanParameterDefinition>
                <hudson.model.StringParameterDefinition>
                    <name>ROLL_VERSION_OVERRIDE</name>
                    <description>Test</description>
                    <trim>true</trim>
                </hudson.model.StringParameterDefinition>
            </parameterDefinitions>
        </hudson.model.ParametersDefinitionProperty>
```
Promotion xml
```
<conditions>
        <hudson.plugins.promoted__builds.conditions.ManualCondition>
            <users/>
            <parameterDefinitions>
                <hudson.model.BooleanParameterDefinition>
                    <name>RESUME_ONLY</name>
                    <description>Test</description>
                    <defaultValue>false</defaultValue>
                </hudson.model.BooleanParameterDefinition>
                <hudson.model.ChoiceParameterDefinition>
                    <name>percent</name>
                    <description>Test</description>
                    <choices class="java.util.Arrays$ArrayList">
                        <a class="string-array">
                            <string>10</string>
                            <string>25</string>
                            <string>50</string>
                            <string>100</string>
                        </a>
                    </choices>
                </hudson.model.ChoiceParameterDefinition>
                <hudson.model.StringParameterDefinition>
                     <name>test</name>
                     <defaultValue>test</defaultValue>
                     <description>test</description>
                 </hudson.model.StringParameterDefinition>
            </parameterDefinitions>
        </hudson.plugins.promoted__builds.conditions.ManualCondition>
    </conditions>
```

DSL Output:
```
parameters {
		parameters {
			choiceParam {
				name("ROLL_ENV")
				choices(["dev", "test", "prod"])
			}
			booleanParam {
				name("DRY_RUN")
				defaultValue(true)
			}
			stringParam {
				name("ROLL_VERSION_OVERRIDE")
				description("Test")
				trim(true)
			}
		}
	}
```
Within promotion:
```
conditions {
		manual("") {
			parameters {
				booleanParam("RESUME_ONLY", false, "Test")
				choiceParam("percent", [10, 25, 50, 100], "Test")
				stringParam("test", "test", "test")
			}
		}
	}
```
