### PR TITLE
[BUILD-3159] Fix do not display empty method and add gitpublisher attributes

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLDoNotDisplayEmptyMethodStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLDoNotDisplayEmptyMethodStrategy.java
@@ -24,6 +24,7 @@ public class DSLDoNotDisplayEmptyMethodStrategy extends DSLMethodStrategy {
     @Override
     public String toDSL() {
         PropertyDescriptor propertyDescriptor = (PropertyDescriptor) getDescriptor();
+
         if (propertyDescriptor.getValue() != null) {
 
             boolean isParentAMethod = propertyDescriptor.getParent() != null &&
@@ -36,10 +37,11 @@ public class DSLDoNotDisplayEmptyMethodStrategy extends DSLMethodStrategy {
             return replaceTabs(String.format(getSyntax("syntax.method_call"),
                     methodName, printValueAccordingOfItsType(propertyDescriptor.getValue())), getTabs());
 
-        } else if (propertyDescriptor.getValue() == null) {
+        } else if (propertyDescriptor.getProperties() != null) {
+            return replaceTabs(String.format(getSyntax("syntax.method_call"),
+                    methodName, getChildrenDSL()), getTabs());
+        } else {
             return "";
         }
-        return replaceTabs(String.format(getSyntax("syntax.method_call"),
-                methodName, getChildrenDSL()), getTabs());
     }
 }

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -408,6 +408,8 @@ hudson.plugins.copyartifact.CopyArtifactPermissionProperty = copyArtifactPermiss
 hudson.plugins.copyartifact.CopyArtifactPermissionProperty.type = OBJECT
 
 hudson.plugins.copyartifact.CopyArtifactPermissionProperty.projectNameList = projectNames
+hudson.plugins.copyartifact.CopyArtifactPermissionProperty.projectNameList.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLDoNotDisplayEmptyMethodStrategy
+
 hudson.plugins.copyartifact.CopyArtifactPermissionProperty.projectNameList.string = string
 hudson.plugins.copyartifact.CopyArtifactPermissionProperty.projectNameList.string.type = PARAMETER
 
@@ -903,6 +905,41 @@ org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.b
 
 org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition = condition
 org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.condition.type = OBJECT
+
+hudson.plugins.git.GitPublisher = gitPublisher
+hudson.plugins.git.GitPublisher.type = OBJECT
+
+hudson.plugins.git.GitPublisher.configVersion = configVersion
+hudson.plugins.git.GitPublisher.pushMerge = pushMerge
+hudson.plugins.git.GitPublisher.pushOnlyIfSuccess = pushOnlyIfSuccess
+hudson.plugins.git.GitPublisher.forcePush = forcePush
+
+hudson.plugins.git.GitPublisher.tagsToPush = tagsToPush
+hudson.plugins.git.GitPublisher.tagsToPush.type = OBJECT
+hudson.plugins.git.GitPublisher_-TagToPush = tagToPush
+hudson.plugins.git.GitPublisher_-TagToPush.type = OBJECT
+hudson.plugins.git.GitPublisher_-TagToPush.targetRepoName = targetRepoName
+hudson.plugins.git.GitPublisher_-TagToPush.tagName = tagName
+hudson.plugins.git.GitPublisher_-TagToPush.tagMessage = tagMessage
+hudson.plugins.git.GitPublisher_-TagToPush.createTag = createTag
+hudson.plugins.git.GitPublisher_-TagToPush.updateTag = updateTag
+
+hudson.plugins.git.GitPublisher.branchesToPush = branchesToPush
+hudson.plugins.git.GitPublisher.branchesToPush.type = OBJECT
+hudson.plugins.git.GitPublisher_-BranchToPush = branchToPush
+hudson.plugins.git.GitPublisher_-BranchToPush.type = OBJECT
+hudson.plugins.git.GitPublisher_-BranchToPush.targetRepoName = targetRepoName
+hudson.plugins.git.GitPublisher_-BranchToPush.branchName = branchName
+hudson.plugins.git.GitPublisher_-BranchToPush.rebaseBeforePush = rebaseBeforePush
+
+hudson.plugins.git.GitPublisher.notesToPush = notesToPush
+hudson.plugins.git.GitPublisher.notesToPush.type = OBJECT
+hudson.plugins.git.GitPublisher_-NoteToPush = noteToPush
+hudson.plugins.git.GitPublisher_-NoteToPush.type = OBJECT
+hudson.plugins.git.GitPublisher_-NoteToPush.targetRepoName = targetRepoName
+hudson.plugins.git.GitPublisher_-NoteToPush.noteMsg = noteMsg
+hudson.plugins.git.GitPublisher_-NoteToPush.noteNamespace = noteNamespace
+hudson.plugins.git.GitPublisher_-NoteToPush.noteReplace = noteReplace
 
 worstResult = worstResult
 worstResult.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLEnclosedObjectStrategy


### PR DESCRIPTION
## Ticket

[BUILD-3159](https://jira.tinyspeck.com/browse/BUILD-3159)

## Overview
The [job the ticket originally used as its example](https://jenkins.tinyspeck.com/job/workday_csv_to_yaml/config.xml) had the copyArtifact XML attribute that was empty like so:
```
<hudson.plugins.copyartifact.CopyArtifactPermissionProperty plugin="copyartifact@1.46.4">
<projectNameList/>
</hudson.plugins.copyartifact.CopyArtifactPermissionProperty>
```
Which was causing a DSL failure on building the job. I wanted to use the `DSLDoNotDisplayEmptyMethodStrategy` but it was switching off whether the method had a value or not. This is not always the case, sometimes the method uses its children instead. So I updated the if / else statement to account for that.
* Tested this with the above XML ie no value, no children  ✅ 
* Tested with the above XML but with valid children attributes ✅ 
* Tested the above with a valid value ✅  (I used the SlackNotifier attributes)

The main meat of the PR though is based around the [gitPublisher](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.gitPublisher) which while huge is pretty straightforward. Just needed a lot of attributes to be added in translator.properties. 

## Testing

Test XML Used:
```
<hudson.plugins.git.GitPublisher plugin="git@4.13.0">
            <configVersion>2</configVersion>
            <pushMerge>true</pushMerge>
            <pushOnlyIfSuccess>true</pushOnlyIfSuccess>
            <forcePush>false</forcePush>
            <tagsToPush>
                <hudson.plugins.git.GitPublisher_-TagToPush>
                    <targetRepoName>test</targetRepoName>
                    <tagName>hi mom</tagName>
                    <tagMessage>hello mother</tagMessage>
                    <createTag>false</createTag>
                    <updateTag>false</updateTag>
                </hudson.plugins.git.GitPublisher_-TagToPush>
            </tagsToPush>
            <branchesToPush>
                <hudson.plugins.git.GitPublisher_-BranchToPush>
                    <targetRepoName>origin</targetRepoName>
                    <branchName>BUILD-3087-stringParam-dsl-testing</branchName>
                    <rebaseBeforePush>false</rebaseBeforePush>
                </hudson.plugins.git.GitPublisher_-BranchToPush>
            </branchesToPush>
            <notesToPush>
                <hudson.plugins.git.GitPublisher_-NoteToPush>
                    <targetRepoName>note name</targetRepoName>
                    <noteMsg>this is a note</noteMsg>
                    <noteNamespace>pam</noteNamespace>
                    <noteReplace>true</noteReplace>
                </hudson.plugins.git.GitPublisher_-NoteToPush>
                <hudson.plugins.git.GitPublisher_-NoteToPush>
                    <targetRepoName>pam</targetRepoName>
                    <noteMsg>second note</noteMsg>
                    <noteNamespace>pam 2</noteNamespace>
                    <noteReplace>false</noteReplace>
                </hudson.plugins.git.GitPublisher_-NoteToPush>
            </notesToPush>
        </hudson.plugins.git.GitPublisher>
```

DSL Output:
```
gitPublisher {
			pushMerge(true)
			pushOnlyIfSuccess(true)
			forcePush(false)
			tagsToPush {
				tagToPush {
					targetRepoName("test")
					tagName("hi mom")
					tagMessage("hello mother")
					createTag(false)
					updateTag(false)
				}
			}
			branchesToPush {
				branchToPush {
					targetRepoName("origin")
					branchName("BUILD-3087-stringParam-dsl-testing")
					rebaseBeforePush(false)
				}
			}
			notesToPush {
				noteToPush {
					targetRepoName("note name")
					noteMsg("this is a note")
					noteNamespace("pam")
					noteReplace(true)
				}
				noteToPush {
					targetRepoName("pam")
					noteMsg("second note")
					noteNamespace("pam 2")
					noteReplace(false)
				}
			}
		}
```
