### PR TITLE
BUILD-3166-correct parameterDefinitions name and position

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -265,9 +265,9 @@ retainCharacteristicEnvVars = retainCharacteristicEnvVars
 processVariablesHandling = processVariablesHandling
 
 hudson.model.ParametersDefinitionProperty = parameters
-hudson.model.ParametersDefinitionProperty.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLObjectIgnoreParentStrategy
+hudson.model.ParametersDefinitionProperty.type = OBJECT
 
-hudson.model.ParametersDefinitionProperty.parameterDefinitions = parameters
+hudson.model.ParametersDefinitionProperty.parameterDefinitions = parameterDefinitions
 hudson.model.ParametersDefinitionProperty.parameterDefinitions.type = OBJECT
 
 hudson.model.ParametersDefinitionProperty.parameterDefinitions.hudson.model.StringParameterDefinition = stringParam


### PR DESCRIPTION
## Ticket

[JIRA-3166](https://jira.tinyspeck.com/browse/BUILD-3166)

## Overview
[This PR](https://github.com/tinyspeck/xml-job-to-job-dsl-plugin/pull/70) made it so that build parameters in the root config.xml use the [dynamic dsl](https://jenkins.tinyspeck.com/plugin/job-dsl/api-viewer/index.html#path/javaposse.jobdsl.dsl.helpers.properties.PropertiesContext.parameters-parameterDefinitions) and build parameters within promotions use the older syntax since the dynamic dsl isn't supported within promotions. 

The dynamic dsl should be nested under properties, so we no longer need to ignore the parent and add  a `parameters` block. It should instead be nested within a parametersDefinition block.

## Testing
Validated the latest DSL completed the seed job ✅
Job built successfully ✅
stringParams, choiceParams and booleanParams configured correctly for both job and promotion ✅

Test XML Used:
```
<properties>
        <hudson.model.ParametersDefinitionProperty>
            <parameterDefinitions>
                <hudson.model.StringParameterDefinition>
                    <name>BRANCH</name>
                    <description>branch to build</description>
                    <defaultValue>master</defaultValue>
                    <trim>false</trim>
                </hudson.model.StringParameterDefinition>
            </parameterDefinitions>
        </hudson.model.ParametersDefinitionProperty>
    </properties>
```

```
<conditions>
        <hudson.plugins.promoted__builds.conditions.ManualCondition>
            <users/>
            <parameterDefinitions>
                <hudson.model.BooleanParameterDefinition>
                    <name>RESUME_ONLY</name>
                    <description>Test</description>
                    <defaultValue>false</defaultValue>
                </hudson.model.BooleanParameterDefinition>
                <hudson.model.ChoiceParameterDefinition>
                    <name>percent</name>
                    <description>Test</description>
                    <choices class="java.util.Arrays$ArrayList">
                        <a class="string-array">
                            <string>10</string>
                            <string>25</string>
                            <string>50</string>
                            <string>100</string>
                        </a>
                    </choices>
                </hudson.model.ChoiceParameterDefinition>
                <hudson.model.StringParameterDefinition>
                    <name>test</name>
                    <defaultValue>test</defaultValue>
                    <description>test</description>
                </hudson.model.StringParameterDefinition>
            </parameterDefinitions>
        </hudson.plugins.promoted__builds.conditions.ManualCondition>
    </conditions>
```

DSL Output:
```
properties {
		promotions {
			promotion {
				name("Promotion 1")
				keepDependencies(false)
				disabled(false)
				concurrentBuild(false)
				conditions {
					manual("") {
						parameters {
							booleanParam("RESUME_ONLY", false, "Test")
							choiceParam("percent", ["10", "25", "50", "100"], "Test")
							stringParam("test", "test", "test")
						}
					}
				}
				icon("star-orange")
				actions {
					copyArtifacts("Test job") {
						includePatterns("Test")
						targetDirectory("Test")
						buildSelector {
							buildNumber("Test")
						}
						flatten(true)
						fingerprintArtifacts(true)
					}
					shell("Test")
				}
			}
		}
		parameters {
			parameterDefinitions {
				stringParam {
					name("BRANCH")
					description("branch to build")
					defaultValue("master")
					trim(false)
				}
			}
		}
	}
```
