### PR TITLE
BUILD-3157-assignedLabel within promotions

### DIFF
--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -16,6 +16,8 @@ matrix-project.type = INNER
 
 assignedNode = label
 
+assignedLabel = restrict
+
 keepDependencies = keepDependencies
 
 properties = properties


### PR DESCRIPTION
## Ticket

[JIRA-3157](https://jira.tinyspeck.com/browse/BUILD-3157)

## Overview
`assignedLabel` was not being supported. This should add a label within promotions for "Restrict where this promotion process can be run". 

<img width="718" alt="Screenshot 2023-01-17 at 4 20 03 PM" src="https://user-images.githubusercontent.com/112515811/213014674-357f29d9-5376-4385-85ce-dde584472454.png">


The docs for the promoted builds plugin don't have any explicit information on how this should look in the dsl.  Digging around Jenkins tickets I found [this](https://issues.jenkins.io/browse/JENKINS-42015) and [this](https://issues.jenkins.io/browse/JENKINS-34074?jql=text%20~%20%22restrict%20promotion%22), indicating that it should be under the `restrict` property. 


## Testing
Tested with several jobs containing assignedLabel :
Validated the latest DSL completed the seed job ✅
Job built successfully ✅
Promotions correctly have the label for "Restrict where this promotion process can be run" ✅

Test XML Used:
```
<hudson.plugins.promoted__builds.PromotionProcess plugin="promoted-builds@3.5">
    <conditions>
        <hudson.plugins.promoted__builds.conditions.SelfPromotionCondition>
            <evenIfUnstable>false</evenIfUnstable>
        </hudson.plugins.promoted__builds.conditions.SelfPromotionCondition>
    </conditions>
    <icon>star-silver</icon>
    <assignedLabel>ops</assignedLabel>
</hudson.plugins.promoted__builds.PromotionProcess>
```

DSL Output:
```
promotions {
			promotion {
				name("(1) staging")
				keepDependencies(false)
				disabled(false)
				concurrentBuild(false)
				conditions {
					selfPromotion(false)
				}
				icon("star-silver")
				restrict("ops")
```
