### PR TITLE
[BUILD-3156] Initial Browser support

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLUseClassNameStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLUseClassNameStrategy.java
@@ -5,6 +5,11 @@ import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
 
 import java.util.List;
 
+/* Usage:
+For example, the browser -> url XML can become different DSL attributes depending on the class of the parent (browser)
+Therefore this class will replace the parent name of the child with the class name, ie url -> hudson.plugins.git.browser.GithubWeb.url
+This way the specific children may be referred to in translator.properties as normal.
+* */
 public class DSLUseClassNameStrategy extends DSLObjectStrategy {
     private final String name;
 
@@ -20,16 +25,18 @@ public class DSLUseClassNameStrategy extends DSLObjectStrategy {
     }
 
     private void changeChildrensNames(PropertyDescriptor propertyDescriptor){
-        String className = propertyDescriptor.getAttributes().get("class");
-        if(className != null) {
-            List<PropertyDescriptor> children = propertyDescriptor.getProperties();
-            for(PropertyDescriptor child : children){
-                if(child.getAttributes() == null || child.getAttributes().get("ChangedName") != "true") {
-                    child.addAttribute("ChangedName", "true");
-                    child.changeName(String.format("%s.%s", className, child.getName()));
+        if(propertyDescriptor.getAttributes() != null) {
+            String className = propertyDescriptor.getAttributes().get("class");
+            if (className != null) {
+                List<PropertyDescriptor> children = propertyDescriptor.getProperties();
+                for (PropertyDescriptor child : children) {
+                    if (child.getAttributes() == null || child.getAttributes().get("ChangedName") != "true") {
+                        child.addAttribute("ChangedName", "true");
+                        child.changeName(String.format("%s.%s", className, child.getName()));
+                    }
                 }
+                initChildren(propertyDescriptor);
             }
-            initChildren(propertyDescriptor);
         }
     }
 }

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLUseClassNameStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLUseClassNameStrategy.java
@@ -1,0 +1,35 @@
+package com.adq.jenkins.xmljobtodsl.dsl.strategies.custom;
+
+import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLObjectStrategy;
+import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
+
+import java.util.List;
+
+public class DSLUseClassNameStrategy extends DSLObjectStrategy {
+    private final String name;
+
+    public DSLUseClassNameStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name) {
+        this(tabs, propertyDescriptor, name, true);
+        changeChildrensNames(propertyDescriptor);
+    }
+
+    public DSLUseClassNameStrategy(int tabs, PropertyDescriptor propertyDescriptor, String name, boolean shouldInitChildren) {
+        super(tabs, propertyDescriptor, name, shouldInitChildren);
+        this.name = name;
+        changeChildrensNames(propertyDescriptor);
+    }
+
+    private void changeChildrensNames(PropertyDescriptor propertyDescriptor){
+        String className = propertyDescriptor.getAttributes().get("class");
+        if(className != null) {
+            List<PropertyDescriptor> children = propertyDescriptor.getProperties();
+            for(PropertyDescriptor child : children){
+                if(child.getAttributes() == null || child.getAttributes().get("ChangedName") != "true") {
+                    child.addAttribute("ChangedName", "true");
+                    child.changeName(String.format("%s.%s", className, child.getName()));
+                }
+            }
+            initChildren(propertyDescriptor);
+        }
+    }
+}

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/parsers/PropertyDescriptor.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/parsers/PropertyDescriptor.java
@@ -58,6 +58,11 @@ public class PropertyDescriptor implements IDescriptor {
         return name;
     }
 
+    public String changeName(String name){
+        this.name = name;
+        return this.name;
+    }
+
     public List<PropertyDescriptor> getProperties() {
         return properties;
     }

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -476,7 +476,13 @@ git.type = OBJECT
 scm.browser = browser
 scm.browser.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLUseClassNameStrategy
 
-hudson.plugins.git.browser.GithubWeb.url = gitWeb
+hudson.plugins.git.browser.GithubWeb.url = repoUrl
+hudson.plugins.git.browser.GithubWeb.url.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLEnclosedObjectStrategy
+hudson.plugins.git.browser.GithubWeb.url.enclosing_tag = gitWeb
+hudson.plugins.git.browser.GithubWeb.urlEnclosed = repoUrl
+hudson.plugins.git.browser.GithubWeb.urlEnclosed.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLMandatoryStringStrategy
+hudson.plugins.git.browser.GithubWeb.gitWeb = gitWeb
+hudson.plugins.git.browser.GithubWeb.gitWeb.type = OBJECT
 
 hudson.plugins.git.browser.AssemblaWeb.url = repoUrl
 hudson.plugins.git.browser.AssemblaWeb.url.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLEnclosedObjectStrategy

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -478,6 +478,14 @@ scm.browser.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLUseClass
 
 hudson.plugins.git.browser.GithubWeb.url = gitWeb
 
+hudson.plugins.git.browser.AssemblaWeb.url = repoUrl
+hudson.plugins.git.browser.AssemblaWeb.url.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLEnclosedObjectStrategy
+hudson.plugins.git.browser.AssemblaWeb.url.enclosing_tag = assemblaWeb
+hudson.plugins.git.browser.AssemblaWeb.urlEnclosed = repoUrl
+hudson.plugins.git.browser.AssemblaWeb.urlEnclosed.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLMandatoryStringStrategy
+hudson.plugins.git.browser.AssemblaWeb.assemblaWeb = assemblaWeb
+hudson.plugins.git.browser.AssemblaWeb.assemblaWeb.type = OBJECT
+
 doGenerateSubmoduleConfigurations=doGenerateSubmoduleConfigurations
 doGenerateSubmoduleConfigurations.type=OBJECT
 

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -473,6 +473,11 @@ hudson.plugins.git.GitSCM.type = OBJECT
 git = git
 git.type = OBJECT
 
+scm.browser = browser
+scm.browser.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLUseClassNameStrategy
+
+hudson.plugins.git.browser.GithubWeb.url = gitWeb
+
 doGenerateSubmoduleConfigurations=doGenerateSubmoduleConfigurations
 doGenerateSubmoduleConfigurations.type=OBJECT
 


### PR DESCRIPTION
## Ticket

[BUILD-3156](https://jira.tinyspeck.com/browse/BUILD-3156)

## Overview
* Add a custom class for using a class name to determine the outcome of an attributes children
* For browser this means we refer to each child with `<classname>.<childname>`
* Add support for Browser for gitWeb and assemblaWeb
* AssemblaWeb requires a string in repoUrl

## Testing
Tested with the two jobs mentioned in the ticket's XML
* https://jenkins.tinyspeck.com/job/update-api-metadata/config.xml
* https://jenkins.tinyspeck.com/job/apache2-bionic/config.xml

And validated that the DSL built correctly on the test cluster

DSL Output:
```
		git {
			remote {
				url("git@slack-github.com:slack/webapp.git")
				credentials("Jenkins-GHE")
			}
			branch("*/master")
			browser {
				assemblaWeb {
					repoUrl("")
				}
			}
			extensions {
				relativeTargetDirectory("webapp")
			}
		}
	}
```

```
scm {
		git {
			remote {
				url("git@slack-github.com:slack/apache2.git")
				credentials("Jenkins-GHE")
			}
			branch("*/main")
			browser {
				gitWeb {
					repoUrl("https://slack-github.com/slack/apache2")
				}
			}
			extensions {
				cloneOptions {
					noTags(false)
					reference("")
					honorRefspec(false)
				}
				submoduleOptions {
					disable(false)
					recursive(true)
					tracking(false)
					reference("")
					parentCredentials(false)
				}
			}
		}
	}
```
